### PR TITLE
chore(js-ts): Complete TypeScript migration for Redux reducers and components

### DIFF
--- a/app/components/UI/Bridge/hooks/useGoToPortfolioBridge.ts
+++ b/app/components/UI/Bridge/hooks/useGoToPortfolioBridge.ts
@@ -6,11 +6,12 @@ import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 import { selectEvmChainId } from '../../../../selectors/networkController';
 
-import type { BrowserTab } from '../../Tokens/types';
+import type { BrowserTab } from '../../../../reducers/browser';
 import type { BrowserParams } from '../../../Views/Browser/Browser.types';
 import { getDecimalChainId } from '../../../../util/networks';
 import { useMetrics } from '../../../hooks/useMetrics';
 import { isBridgeUrl } from '../../../../util/url';
+import type { RootState } from '../../../../reducers';
 
 /**
  * Returns a function that is used to navigate to the MetaMask Bridges webpage.
@@ -19,9 +20,7 @@ import { isBridgeUrl } from '../../../../util/url';
  */
 export default function useGoToPortfolioBridge(location: string) {
   const chainId = useSelector(selectEvmChainId);
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const browserTabs = useSelector((state: any) => state.browser.tabs);
+  const browserTabs = useSelector((state: RootState) => state.browser.tabs);
   const { navigate } = useNavigation();
   const { trackEvent, createEventBuilder } = useMetrics();
   return (address?: string) => {
@@ -29,7 +28,7 @@ export default function useGoToPortfolioBridge(location: string) {
       isBridgeUrl(tab.url),
     );
 
-    const params: BrowserParams & { existingTabId?: string } = {
+    const params: BrowserParams & { existingTabId?: number } = {
       timestamp: Date.now(),
     };
 

--- a/app/components/UI/Ramp/components/Account.tsx
+++ b/app/components/UI/Ramp/components/Account.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import EthereumAddress from '../../EthereumAddress';
-import JSIdenticon from '../../Identicon';
+import Identicon from '../../Identicon';
 import Text from '../../../Base/Text';
 import { View, StyleSheet } from 'react-native';
 import { useTheme } from '../../../../util/theme';
@@ -12,11 +12,6 @@ import {
   selectInternalAccounts,
 } from '../../../../selectors/accountsController';
 import { toLowerCaseEquals } from '../../../../util/general';
-
-// TODO: Convert into typescript and correctly type
-// TODO: Replace "any" with type
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const Identicon = JSIdenticon as any;
 
 const createStyles = (colors: Colors) =>
   StyleSheet.create({

--- a/app/components/UI/Ramp/components/LoadingAnimation/index.tsx
+++ b/app/components/UI/Ramp/components/LoadingAnimation/index.tsx
@@ -9,16 +9,11 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import Device from '../../../../../util/device';
-import BaseTitle from '../../../../Base/Title';
+import Title from '../../../../Base/Title';
 import ShapesBackgroundAnimation from '../../../Swaps/components/LoadingAnimation/ShapesBackgroundAnimation';
 import { useTheme } from '../../../../../util/theme';
 import { Colors } from '../../../../../util/theme/models';
 import foxImage from '../../../../../images/branding/fox.png';
-
-// TODO: Convert into typescript and correctly type
-// TODO: Replace "any" with type
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const Title = BaseTitle as any;
 
 const ANIM_MULTIPLIER = 0.67;
 const START_DURATION = 1000 * ANIM_MULTIPLIER;
@@ -88,9 +83,7 @@ const createStyles = (
 interface Props {
   title: string;
   finish: boolean;
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onAnimationEnd?: () => any;
+  onAnimationEnd?: () => void;
   asScreen?: boolean;
 }
 

--- a/app/components/UI/Stake/components/StakeButton/index.tsx
+++ b/app/components/UI/Stake/components/StakeButton/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TokenI } from '../../../Tokens/types';
-import { BrowserTab } from '../../../../../reducers/browser';
+import type { BrowserTab } from '../../../../../reducers/browser';
 import { useNavigation } from '@react-navigation/native';
 import Routes from '../../../../../constants/navigation/Routes';
 import { useSelector } from 'react-redux';

--- a/app/components/UI/Stake/components/StakeButton/index.tsx
+++ b/app/components/UI/Stake/components/StakeButton/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { TokenI, BrowserTab } from '../../../Tokens/types';
+import { TokenI } from '../../../Tokens/types';
+import { BrowserTab } from '../../../../../reducers/browser';
 import { useNavigation } from '@react-navigation/native';
 import Routes from '../../../../../constants/navigation/Routes';
 import { useSelector } from 'react-redux';

--- a/app/components/UI/Tokens/TokenList/PortfolioBalance/index.tsx
+++ b/app/components/UI/Tokens/TokenList/PortfolioBalance/index.tsx
@@ -25,7 +25,7 @@ import Icon, {
   IconSize,
   IconName,
 } from '../../../../../component-library/components/Icons/Icon';
-import { BrowserTab } from '../../types';
+import { BrowserTab } from '../../../../../reducers/browser';
 import { WalletViewSelectorsIDs } from '../../../../../../e2e/selectors/wallet/WalletView.selectors';
 import { strings } from '../../../../../../locales/i18n';
 import { EYE_SLASH_ICON_TEST_ID, EYE_ICON_TEST_ID } from './index.constants';

--- a/app/components/UI/Tokens/TokenList/PortfolioBalance/index.tsx
+++ b/app/components/UI/Tokens/TokenList/PortfolioBalance/index.tsx
@@ -25,7 +25,7 @@ import Icon, {
   IconSize,
   IconName,
 } from '../../../../../component-library/components/Icons/Icon';
-import { BrowserTab } from '../../../../../reducers/browser';
+import type { BrowserTab } from '../../../../../reducers/browser';
 import { WalletViewSelectorsIDs } from '../../../../../../e2e/selectors/wallet/WalletView.selectors';
 import { strings } from '../../../../../../locales/i18n';
 import { EYE_SLASH_ICON_TEST_ID, EYE_ICON_TEST_ID } from './index.constants';

--- a/app/components/UI/Tokens/types.ts
+++ b/app/components/UI/Tokens/types.ts
@@ -1,8 +1,3 @@
-export interface BrowserTab {
-  id: string;
-  url: string;
-}
-
 export interface TokenI {
   address: string;
   aggregators: string[];

--- a/app/components/Views/Asset/utils.ts
+++ b/app/components/Views/Asset/utils.ts
@@ -13,7 +13,6 @@ import { RootState } from '../../../reducers';
 
 export const getSwapsIsLive = (state: RootState, chainId: Hex | CaipChainId) => {
   const evmSwapsIsLive = isPortfolioViewEnabled()
-    // @ts-expect-error issues with the type, it should have 2 args
     ? swapsLivenessMultichainSelector(state, chainId)
     : swapsLivenessSelector(state);
   let swapsIsLive = evmSwapsIsLive;

--- a/app/components/Views/AssetOptions/AssetOptions.tsx
+++ b/app/components/Views/AssetOptions/AssetOptions.tsx
@@ -30,7 +30,8 @@ import {
   isPortfolioViewEnabled,
 } from '../../../util/networks';
 import { isPortfolioUrl } from '../../../util/url';
-import { BrowserTab, TokenI } from '../../../components/UI/Tokens/types';
+import { TokenI } from '../../../components/UI/Tokens/types';
+import type { BrowserTab } from '../../../reducers/browser';
 import { RootState } from '../../../reducers';
 import { Hex } from '@metamask/utils';
 import { appendURLParams } from '../../../util/browser';
@@ -68,8 +69,7 @@ const AssetOptions = (props: Props) => {
   );
   const tokenList = useSelector(selectTokenList);
   const chainId = useSelector(selectEvmChainId);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const browserTabs = useSelector((state: any) => state.browser.tabs);
+  const browserTabs = useSelector((state: RootState) => state.browser.tabs);
   const isDataCollectionForMarketingEnabled = useSelector(
     (state: RootState) => state.security.dataCollectionForMarketing,
   );

--- a/app/reducers/accounts/index.ts
+++ b/app/reducers/accounts/index.ts
@@ -7,6 +7,8 @@ export interface iAccountEvent {
   reloadAccounts: boolean;
 }
 
+export type AccountsState = iAccountEvent;
+
 /**
  * Initial state of the Accounts event flow
  */

--- a/app/reducers/accounts/index.ts
+++ b/app/reducers/accounts/index.ts
@@ -12,7 +12,7 @@ export type AccountsState = iAccountEvent;
 /**
  * Initial state of the Accounts event flow
  */
-const initialState: iAccountEvent = {
+export const initialState: iAccountEvent = {
   reloadAccounts: false,
 };
 

--- a/app/reducers/alert/index.ts
+++ b/app/reducers/alert/index.ts
@@ -8,7 +8,7 @@ export interface AlertState {
   data: Record<string, unknown> | null;
 }
 
-const initialState: AlertState = {
+export const initialState: AlertState = {
   isVisible: false,
   autodismiss: null,
   content: null,

--- a/app/reducers/alert/index.ts
+++ b/app/reducers/alert/index.ts
@@ -1,11 +1,24 @@
-const initialState = {
+import { AnyAction } from 'redux';
+import { ReactNode } from 'react';
+
+export interface AlertState {
+  isVisible: boolean;
+  autodismiss: number | null;
+  content: ReactNode | null;
+  data: Record<string, unknown> | null;
+}
+
+const initialState: AlertState = {
   isVisible: false,
   autodismiss: null,
   content: null,
   data: null,
 };
 
-const alertReducer = (state = initialState, action) => {
+const alertReducer = (
+  state: AlertState = initialState,
+  action: AnyAction,
+): AlertState => {
   switch (action.type) {
     case 'SHOW_ALERT':
       return {

--- a/app/reducers/bookmarks/index.ts
+++ b/app/reducers/bookmarks/index.ts
@@ -7,8 +7,10 @@ export interface Bookmark {
 
 export type BookmarksState = Bookmark[];
 
+export const initialState: BookmarksState = [];
+
 const bookmarksReducer = (
-  state: BookmarksState = [],
+  state: BookmarksState = initialState,
   action: AnyAction,
 ): BookmarksState => {
   switch (action.type) {

--- a/app/reducers/bookmarks/index.ts
+++ b/app/reducers/bookmarks/index.ts
@@ -1,4 +1,16 @@
-const bookmarksReducer = (state = [], action) => {
+import { AnyAction } from 'redux';
+
+export interface Bookmark {
+  url: string;
+  name?: string;
+}
+
+export type BookmarksState = Bookmark[];
+
+const bookmarksReducer = (
+  state: BookmarksState = [],
+  action: AnyAction,
+): BookmarksState => {
   switch (action.type) {
     case 'ADD_BOOKMARK':
       return [...state, action.bookmark];

--- a/app/reducers/browser/index.ts
+++ b/app/reducers/browser/index.ts
@@ -28,7 +28,7 @@ export interface BrowserState {
   visitedDappsByHostname: Record<string, boolean>;
 }
 
-const initialState: BrowserState = {
+export const initialState: BrowserState = {
   history: [],
   whitelist: [],
   tabs: [],

--- a/app/reducers/browser/index.ts
+++ b/app/reducers/browser/index.ts
@@ -1,17 +1,46 @@
 import { BrowserActionTypes } from '../../actions/browser';
 import AppConstants from '../../core/AppConstants';
 import { appendURLParams } from '../../util/browser';
+import { AnyAction } from 'redux';
 
-const initialState = {
+export interface BrowserTab {
+  url: string;
+  id: number;
+  linkType?: string;
+}
+
+export interface BrowserHistoryEntry {
+  url: string;
+  name: string;
+}
+
+export interface BrowserFavicon {
+  origin: string;
+  url: string;
+}
+
+export interface BrowserState {
+  history: BrowserHistoryEntry[];
+  whitelist: string[];
+  tabs: BrowserTab[];
+  favicons: BrowserFavicon[];
+  activeTab: number | null;
+  visitedDappsByHostname: Record<string, boolean>;
+}
+
+const initialState: BrowserState = {
   history: [],
   whitelist: [],
   tabs: [],
   favicons: [],
   activeTab: null,
-  // Keep track of viewed Dapps, which is used for MetaMetricsEvents.DAPP_VIEWED event
   visitedDappsByHostname: {},
 };
-const browserReducer = (state = initialState, action) => {
+
+const browserReducer = (
+  state: BrowserState = initialState,
+  action: AnyAction,
+): BrowserState => {
   switch (action.type) {
     case BrowserActionTypes.ADD_TO_VIEWED_DAPP: {
       const { hostname } = action;

--- a/app/reducers/collectibles/index.ts
+++ b/app/reducers/collectibles/index.ts
@@ -31,33 +31,35 @@ export const collectibleContractsSelector = createSelector(
   selectChainId,
   selectAllNftContracts,
   (address, chainId, allNftContracts) =>
-    allNftContracts[address]?.[chainId] || [],
+    (address && chainId && allNftContracts[address]?.[chainId]) || [],
 );
 
 export const multichainCollectibleContractsSelector = createSelector(
   selectSelectedInternalAccountAddress,
   selectAllNftContracts,
-  (address, allNftContracts) => allNftContracts[address] || {},
+  (address, allNftContracts) => (address && allNftContracts[address]) || {},
 );
 
 export const collectiblesSelector = createDeepEqualSelector(
   selectSelectedInternalAccountAddress,
   selectChainId,
   selectAllNfts,
-  (address, chainId, allNfts) => allNfts[address]?.[chainId] || [],
+  (address, chainId, allNfts) =>
+    (address && chainId && allNfts[address]?.[chainId]) || [],
 );
 
 export const multichainCollectiblesSelector = createDeepEqualSelector(
   selectSelectedInternalAccountAddress,
   selectAllNfts,
-  (address, allNfts) => allNfts[address] || {},
+  (address, allNfts) => (address && allNfts[address]) || {},
 );
 
 export const favoritesCollectiblesSelector = createSelector(
   selectSelectedInternalAccountAddress,
   selectChainId,
   favoritesSelector,
-  (address, chainId, favorites) => favorites[address]?.[chainId] || [],
+  (address, chainId, favorites) =>
+    (address && chainId && favorites[address]?.[chainId]) || [],
 );
 
 export const isCollectibleInFavoritesSelector = createSelector(
@@ -66,7 +68,7 @@ export const isCollectibleInFavoritesSelector = createSelector(
   (favoriteCollectibles, collectible) =>
     Boolean(
       favoriteCollectibles.find(
-        ({ tokenId, address }) =>
+        ({ tokenId, address }: FavoriteCollectible) =>
           compareTokenIds(tokenId, collectible.tokenId) &&
           address === collectible.address,
       ),

--- a/app/reducers/collectibles/index.ts
+++ b/app/reducers/collectibles/index.ts
@@ -87,7 +87,7 @@ export const REMOVE_FAVORITE_COLLECTIBLE = 'REMOVE_FAVORITE_COLLECTIBLE';
 export const SHOW_NFT_FETCHING_LOADER = 'SHOW_NFT_FETCHING_LOADER';
 export const HIDE_NFT_FETCHING_LOADER = 'HIDE_NFT_FETCHING_LOADER';
 
-const initialState: CollectiblesState = {
+export const initialState: CollectiblesState = {
   favorites: {},
   isNftFetchingProgress: false,
 };

--- a/app/reducers/collectibles/index.ts
+++ b/app/reducers/collectibles/index.ts
@@ -7,11 +7,24 @@ import {
 import { selectSelectedInternalAccountAddress } from '../../selectors/accountsController';
 import { compareTokenIds } from '../../util/tokens';
 import { createDeepEqualSelector } from '../../selectors/util';
+import { AnyAction } from 'redux';
 
-const favoritesSelector = (state) => state.collectibles.favorites;
+interface FavoriteCollectible {
+  tokenId: string;
+  address: string;
+}
 
-export const isNftFetchingProgressSelector = (state) =>
-  state.collectibles.isNftFetchingProgress;
+export interface CollectiblesState {
+  favorites: Record<string, Record<string, FavoriteCollectible[]>>;
+  isNftFetchingProgress: boolean;
+}
+
+const favoritesSelector = (state: { collectibles: CollectiblesState }) =>
+  state.collectibles.favorites;
+
+export const isNftFetchingProgressSelector = (state: {
+  collectibles: CollectiblesState;
+}) => state.collectibles.isNftFetchingProgress;
 
 export const collectibleContractsSelector = createSelector(
   selectSelectedInternalAccountAddress,
@@ -49,12 +62,11 @@ export const favoritesCollectiblesSelector = createSelector(
 
 export const isCollectibleInFavoritesSelector = createSelector(
   favoritesCollectiblesSelector,
-  (state, collectible) => collectible,
+  (state: unknown, collectible: FavoriteCollectible) => collectible,
   (favoriteCollectibles, collectible) =>
     Boolean(
       favoriteCollectibles.find(
         ({ tokenId, address }) =>
-          // TO DO: Remove after moving favorites to controllers.
           compareTokenIds(tokenId, collectible.tokenId) &&
           address === collectible.address,
       ),
@@ -62,22 +74,26 @@ export const isCollectibleInFavoritesSelector = createSelector(
 );
 
 const getFavoritesCollectibles = (
-  favoriteCollectibles,
-  selectedAddress,
-  chainId,
-) => favoriteCollectibles[selectedAddress]?.[chainId] || [];
+  favoriteCollectibles: Record<string, Record<string, FavoriteCollectible[]>>,
+  selectedAddress: string,
+  chainId: string,
+): FavoriteCollectible[] =>
+  favoriteCollectibles[selectedAddress]?.[chainId] || [];
 
 export const ADD_FAVORITE_COLLECTIBLE = 'ADD_FAVORITE_COLLECTIBLE';
 export const REMOVE_FAVORITE_COLLECTIBLE = 'REMOVE_FAVORITE_COLLECTIBLE';
 export const SHOW_NFT_FETCHING_LOADER = 'SHOW_NFT_FETCHING_LOADER';
 export const HIDE_NFT_FETCHING_LOADER = 'HIDE_NFT_FETCHING_LOADER';
 
-const initialState = {
+const initialState: CollectiblesState = {
   favorites: {},
   isNftFetchingProgress: false,
 };
 
-const collectiblesFavoritesReducer = (state = initialState, action) => {
+const collectiblesFavoritesReducer = (
+  state: CollectiblesState = initialState,
+  action: AnyAction,
+): CollectiblesState => {
   switch (action.type) {
     case ADD_FAVORITE_COLLECTIBLE: {
       const { selectedAddress, chainId, collectible } = action;
@@ -112,7 +128,6 @@ const collectiblesFavoritesReducer = (state = initialState, action) => {
       );
       const indexToRemove = collectibles.findIndex(
         ({ tokenId, address }) =>
-          // TO DO: Remove after moving favorites to controllers.
           compareTokenIds(tokenId, collectible.tokenId) &&
           address === collectible.address,
       );

--- a/app/reducers/collectibles/index.ts
+++ b/app/reducers/collectibles/index.ts
@@ -31,7 +31,7 @@ export const collectibleContractsSelector = createSelector(
   selectChainId,
   selectAllNftContracts,
   (address, chainId, allNftContracts) =>
-    (address && chainId && allNftContracts[address]?.[chainId]) || [],
+    (address && chainId && typeof chainId === 'string' && chainId.startsWith('0x') && allNftContracts[address]?.[chainId as `0x${string}`]) || [],
 );
 
 export const multichainCollectibleContractsSelector = createSelector(
@@ -45,7 +45,7 @@ export const collectiblesSelector = createDeepEqualSelector(
   selectChainId,
   selectAllNfts,
   (address, chainId, allNfts) =>
-    (address && chainId && allNfts[address]?.[chainId]) || [],
+    (address && chainId && typeof chainId === 'string' && chainId.startsWith('0x') && allNfts[address]?.[chainId as `0x${string}`]) || [],
 );
 
 export const multichainCollectiblesSelector = createDeepEqualSelector(

--- a/app/reducers/experimentalSettings/index.ts
+++ b/app/reducers/experimentalSettings/index.ts
@@ -5,17 +5,21 @@ import {
   SetSecurityAlertsEnabled,
 } from '../../actions/experimental';
 
-const initialState = {
+export interface ExperimentalSettingsState {
+  securityAlertsEnabled: boolean;
+}
+
+const initialState: ExperimentalSettingsState = {
   securityAlertsEnabled: true,
 };
 
 const experimentalSettingsReducer = (
-  state = initialState,
+  state: ExperimentalSettingsState = initialState,
   action: {
     securityAlertsEnabled: SetSecurityAlertsEnabled;
     type: string;
   },
-) => {
+): ExperimentalSettingsState => {
   switch (action.type) {
     case ActionType.SET_SECURITY_ALERTS_ENABLED:
       return {

--- a/app/reducers/experimentalSettings/index.ts
+++ b/app/reducers/experimentalSettings/index.ts
@@ -15,16 +15,13 @@ export const initialState: ExperimentalSettingsState = {
 
 const experimentalSettingsReducer = (
   state: ExperimentalSettingsState = initialState,
-  action: {
-    securityAlertsEnabled: SetSecurityAlertsEnabled;
-    type: string;
-  },
+  action: SetSecurityAlertsEnabled | { type: string },
 ): ExperimentalSettingsState => {
   switch (action.type) {
     case ActionType.SET_SECURITY_ALERTS_ENABLED:
       return {
         ...state,
-        securityAlertsEnabled: action.securityAlertsEnabled,
+        securityAlertsEnabled: (action as SetSecurityAlertsEnabled).securityAlertsEnabled,
       };
     default:
       return state;

--- a/app/reducers/experimentalSettings/index.ts
+++ b/app/reducers/experimentalSettings/index.ts
@@ -9,7 +9,7 @@ export interface ExperimentalSettingsState {
   securityAlertsEnabled: boolean;
 }
 
-const initialState: ExperimentalSettingsState = {
+export const initialState: ExperimentalSettingsState = {
   securityAlertsEnabled: true,
 };
 

--- a/app/reducers/index.ts
+++ b/app/reducers/index.ts
@@ -1,29 +1,29 @@
-import bookmarksReducer from './bookmarks';
-import browserReducer from './browser';
+import bookmarksReducer, { BookmarksState } from './bookmarks';
+import browserReducer, { BrowserState } from './browser';
 import engineReducer from '../core/redux/slices/engine';
-import privacyReducer from './privacy';
-import modalsReducer from './modals';
-import settingsReducer from './settings';
-import alertReducer from './alert';
-import transactionReducer from './transaction';
+import privacyReducer, { PrivacyState } from './privacy';
+import modalsReducer, { ModalsState } from './modals';
+import settingsReducer, { SettingsState } from './settings';
+import alertReducer, { AlertState } from './alert';
+import transactionReducer, { TransactionState } from './transaction';
 import legalNoticesReducer from './legalNotices';
 import userReducer, { UserState } from './user';
-import wizardReducer from './wizard';
+import wizardReducer, { WizardState } from './wizard';
 import onboardingReducer, { OnboardingState } from './onboarding';
 import fiatOrders from './fiatOrders';
-import swapsReducer from './swaps';
-import signatureRequestReducer from './signatureRequest';
-import notificationReducer from './notification';
-import infuraAvailabilityReducer from './infuraAvailability';
-import collectiblesReducer from './collectibles';
+import swapsReducer, { SwapsState } from './swaps';
+import signatureRequestReducer, { SignatureRequestState } from './signatureRequest';
+import notificationReducer, { NotificationState } from './notification';
+import infuraAvailabilityReducer, { InfuraAvailabilityState } from './infuraAvailability';
+import collectiblesReducer, { CollectiblesState } from './collectibles';
 import navigationReducer, { NavigationState } from './navigation';
-import networkOnboardReducer from './networkSelector';
+import networkOnboardReducer, { NetworkOnboardedState } from './networkSelector';
 import securityReducer, { SecurityState } from './security';
 import { combineReducers, Reducer } from 'redux';
-import experimentalSettingsReducer from './experimentalSettings';
+import experimentalSettingsReducer, { ExperimentalSettingsState } from './experimentalSettings';
 import { EngineState } from '../core/Engine';
-import rpcEventReducer from './rpcEvents';
-import accountsReducer from './accounts';
+import rpcEventReducer, { RpcEventsState } from './rpcEvents';
+import accountsReducer, { AccountsState } from './accounts';
 import sdkReducer from './sdk';
 import inpageProviderReducer from '../core/redux/slices/inpageProvider';
 import confirmationMetricsReducer from '../core/redux/slices/confirmationMetrics';
@@ -54,69 +54,31 @@ export type StateFromReducer<reducer> = reducer extends Reducer<
 // to this type. Once that is complete, we can automatically generate this type
 // using the `StateFromReducersMapObject` type from redux.
 export interface RootState {
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  legalNotices: any;
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  collectibles: any;
+  legalNotices: StateFromReducer<typeof legalNoticesReducer>;
+  collectibles: CollectiblesState;
   engine: { backgroundState: EngineState };
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  privacy: any;
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  bookmarks: any;
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  browser: any;
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  modals: any;
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  settings: any;
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  alert: any;
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  transaction: any;
+  privacy: PrivacyState;
+  bookmarks: BookmarksState;
+  browser: BrowserState;
+  modals: ModalsState;
+  settings: SettingsState;
+  alert: AlertState;
+  transaction: TransactionState;
   user: UserState;
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  wizard: any;
+  wizard: WizardState;
   onboarding: OnboardingState;
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  notification: any;
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  swaps: any;
+  notification: NotificationState;
+  swaps: SwapsState;
   fiatOrders: StateFromReducer<typeof fiatOrders>;
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  infuraAvailability: any;
+  infuraAvailability: InfuraAvailabilityState;
   navigation: NavigationState;
-  // The networkOnboarded reducer is TypeScript but not yet a valid reducer
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  networkOnboarded: any;
+  networkOnboarded: NetworkOnboardedState;
   security: SecurityState;
   sdk: StateFromReducer<typeof sdkReducer>;
-  // The experimentalSettings reducer is TypeScript but not yet a valid reducer
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  experimentalSettings: any;
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  signatureRequest: any;
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  rpcEvents: any;
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  accounts: any;
+  experimentalSettings: ExperimentalSettingsState;
+  signatureRequest: SignatureRequestState;
+  rpcEvents: RpcEventsState;
+  accounts: AccountsState;
   inpageProvider: StateFromReducer<typeof inpageProviderReducer>;
   confirmationMetrics: StateFromReducer<typeof confirmationMetricsReducer>;
   originThrottling: StateFromReducer<typeof originThrottlingReducer>;

--- a/app/reducers/infuraAvailability/index.ts
+++ b/app/reducers/infuraAvailability/index.ts
@@ -1,4 +1,10 @@
-const initialState = {
+import { AnyAction } from 'redux';
+
+export interface InfuraAvailabilityState {
+  isBlocked: boolean;
+}
+
+const initialState: InfuraAvailabilityState = {
   isBlocked: false,
 };
 
@@ -6,10 +12,14 @@ export const INFURA_AVAILABILITY_BLOCKED = 'INFURA_AVAILABILITY_BLOCKED';
 export const INFURA_AVAILABILITY_NOT_BLOCKED =
   'INFURA_AVAILABILITY_NOT_BLOCKED';
 
-export const getInfuraBlockedSelector = (state) =>
-  state.infuraAvailability?.isBlocked;
+export const getInfuraBlockedSelector = (state: {
+  infuraAvailability?: InfuraAvailabilityState;
+}): boolean | undefined => state.infuraAvailability?.isBlocked;
 
-const infuraAvailabilityReducer = (state = initialState, action) => {
+const infuraAvailabilityReducer = (
+  state: InfuraAvailabilityState = initialState,
+  action: AnyAction,
+): InfuraAvailabilityState => {
   switch (action.type) {
     case INFURA_AVAILABILITY_BLOCKED:
       return {

--- a/app/reducers/infuraAvailability/index.ts
+++ b/app/reducers/infuraAvailability/index.ts
@@ -4,7 +4,7 @@ export interface InfuraAvailabilityState {
   isBlocked: boolean;
 }
 
-const initialState: InfuraAvailabilityState = {
+export const initialState: InfuraAvailabilityState = {
   isBlocked: false,
 };
 

--- a/app/reducers/legalNotices/index.ts
+++ b/app/reducers/legalNotices/index.ts
@@ -35,7 +35,9 @@ export const shouldShowNewPrivacyToastSelector = (
 
   if (newPrivacyPolicyToastClickedOrClosed) return false;
 
-  const shownDate = new Date(newPrivacyPolicyToastShownDate);
+  const shownDate = newPrivacyPolicyToastShownDate 
+    ? new Date(newPrivacyPolicyToastShownDate) 
+    : new Date(0);
 
   const oneDayInMilliseconds = 24 * 60 * 60 * 1000;
   const isRecent =

--- a/app/reducers/legalNotices/index.ts
+++ b/app/reducers/legalNotices/index.ts
@@ -6,7 +6,12 @@ const currentDate = new Date(Date.now());
 const newPrivacyPolicyDate = new Date('2024-06-18T12:00:00Z');
 export const isPastPrivacyPolicyDate = currentDate >= newPrivacyPolicyDate;
 
-const initialState = {
+export interface LegalNoticesState {
+  newPrivacyPolicyToastClickedOrClosed: boolean;
+  newPrivacyPolicyToastShownDate: number | null;
+}
+
+export const initialState: LegalNoticesState = {
   newPrivacyPolicyToastClickedOrClosed: false,
   newPrivacyPolicyToastShownDate: null,
 };
@@ -49,13 +54,13 @@ export interface LegalNoticesAction extends Action {
 }
 
 const legalNoticesReducer = (
-  state = initialState,
+  state: LegalNoticesState = initialState,
   action: LegalNoticesAction = {
     type: '',
     newPrivacyPolicyToastShownDate: false,
     payload: 0,
   },
-) => {
+): LegalNoticesState => {
   switch (action.type) {
     case ACTIONS.STORE_PRIVACY_POLICY_SHOWN_DATE: {
       if (state.newPrivacyPolicyToastShownDate !== null) {

--- a/app/reducers/modals/index.ts
+++ b/app/reducers/modals/index.ts
@@ -1,4 +1,15 @@
-const initialState = {
+import { AnyAction } from 'redux';
+
+export interface ModalsState {
+  networkModalVisible: boolean;
+  shouldNetworkSwitchPopToWallet: boolean;
+  collectibleContractModalVisible: boolean;
+  dappTransactionModalVisible: boolean;
+  signMessageModalVisible: boolean;
+  infoNetworkModalVisible?: boolean;
+}
+
+const initialState: ModalsState = {
   networkModalVisible: false,
   shouldNetworkSwitchPopToWallet: true,
   collectibleContractModalVisible: false,
@@ -6,7 +17,10 @@ const initialState = {
   signMessageModalVisible: true,
 };
 
-const modalsReducer = (state = initialState, action) => {
+const modalsReducer = (
+  state: ModalsState = initialState,
+  action: AnyAction,
+): ModalsState => {
   switch (action.type) {
     case 'TOGGLE_NETWORK_MODAL':
       return {

--- a/app/reducers/modals/index.ts
+++ b/app/reducers/modals/index.ts
@@ -9,7 +9,7 @@ export interface ModalsState {
   infoNetworkModalVisible?: boolean;
 }
 
-const initialState: ModalsState = {
+export const initialState: ModalsState = {
   networkModalVisible: false,
   shouldNetworkSwitchPopToWallet: true,
   collectibleContractModalVisible: false,

--- a/app/reducers/networkSelector/index.ts
+++ b/app/reducers/networkSelector/index.ts
@@ -1,4 +1,18 @@
-export const initialState = {
+export interface NetworkOnboardedState {
+  networkOnboardedState: Record<string, boolean>;
+  networkState: {
+    showNetworkOnboarding: boolean;
+    nativeToken: string;
+    networkType: string;
+    networkUrl: string;
+  };
+  switchedNetwork: {
+    networkUrl: string;
+    networkStatus: boolean;
+  };
+}
+
+export const initialState: NetworkOnboardedState = {
   networkOnboardedState: {},
   networkState: {
     showNetworkOnboarding: false,
@@ -19,7 +33,7 @@ export const initialState = {
  */
 
 function networkOnboardReducer(
-  state = initialState,
+  state: NetworkOnboardedState = initialState,
   action: {
     nativeToken: string;
     networkType: string;
@@ -27,9 +41,7 @@ function networkOnboardReducer(
     networkStatus: boolean;
     showNetworkOnboarding: boolean;
     type: string;
-    // TODO: Replace "any" with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    payload: any;
+    payload: string;
   } = {
     nativeToken: '',
     networkType: '',
@@ -37,9 +49,9 @@ function networkOnboardReducer(
     networkStatus: false,
     showNetworkOnboarding: false,
     type: '',
-    payload: undefined,
+    payload: '',
   },
-) {
+): NetworkOnboardedState {
   switch (action.type) {
     case 'SHOW_NETWORK_ONBOARDING':
       return {

--- a/app/reducers/notification/index.ts
+++ b/app/reducers/notification/index.ts
@@ -1,8 +1,34 @@
 import { createSelector } from 'reselect';
 import { NotificationTypes } from '../../util/notifications';
+import { AnyAction } from 'redux';
 const { TRANSACTION, SIMPLE } = NotificationTypes;
 
-export const initialState = {
+interface TransactionNotification {
+  id: string;
+  isVisible: boolean;
+  autodismiss: number;
+  transaction: unknown;
+  status: string;
+  type: typeof TRANSACTION;
+}
+
+interface SimpleNotification {
+  id: string;
+  isVisible: boolean;
+  autodismiss: number;
+  title: string;
+  description: string;
+  status: string;
+  type: typeof SIMPLE;
+}
+
+type Notification = TransactionNotification | SimpleNotification;
+
+export interface NotificationState {
+  notifications: Notification[];
+}
+
+export const initialState: NotificationState = {
   notifications: [],
 };
 
@@ -21,11 +47,13 @@ export const ACTIONS = {
   UPDATE_NOTIFICATION_STATUS: 'UPDATE_NOTIFICATION_STATUS',
 };
 
-const enqueue = (notifications, notification) => [
-  ...notifications,
-  notification,
-];
-const dequeue = (notifications) => notifications.slice(1);
+const enqueue = (
+  notifications: Notification[],
+  notification: Notification,
+): Notification[] => [...notifications, notification];
+
+const dequeue = (notifications: Notification[]): Notification[] =>
+  notifications.slice(1);
 
 export const currentNotificationSelector = createSelector(
   (
@@ -35,10 +63,12 @@ export const currentNotificationSelector = createSelector(
   (notifications) => notifications[0] || {},
 );
 
-const notificationReducer = (state = initialState, action) => {
+const notificationReducer = (
+  state: NotificationState = initialState,
+  action: AnyAction,
+): NotificationState => {
   const { notifications } = state;
   switch (action.type) {
-    // make current notification isVisible props false
     case ACTIONS.HIDE_CURRENT_NOTIFICATION: {
       if (notifications[0]) {
         return {

--- a/app/reducers/notification/index.ts
+++ b/app/reducers/notification/index.ts
@@ -56,11 +56,8 @@ const dequeue = (notifications: Notification[]): Notification[] =>
   notifications.slice(1);
 
 export const currentNotificationSelector = createSelector(
-  (
-    /** @type {import('..').RootState} */
-    state,
-  ) => state?.notifications,
-  (notifications) => notifications[0] || {},
+  (state: { notification: NotificationState }) => state?.notification?.notifications,
+  (notifications) => notifications?.[0] || {},
 );
 
 const notificationReducer = (

--- a/app/reducers/privacy/index.ts
+++ b/app/reducers/privacy/index.ts
@@ -5,7 +5,7 @@ export interface PrivacyState {
   revealSRPTimestamps: number[];
 }
 
-const initialState: PrivacyState = {
+export const initialState: PrivacyState = {
   approvedHosts: {},
   revealSRPTimestamps: [],
 };

--- a/app/reducers/privacy/index.ts
+++ b/app/reducers/privacy/index.ts
@@ -1,9 +1,19 @@
-const initialState = {
+import { AnyAction } from 'redux';
+
+export interface PrivacyState {
+  approvedHosts: Record<string, boolean>;
+  revealSRPTimestamps: number[];
+}
+
+const initialState: PrivacyState = {
   approvedHosts: {},
   revealSRPTimestamps: [],
 };
 
-const privacyReducer = (state = initialState, action) => {
+const privacyReducer = (
+  state: PrivacyState = initialState,
+  action: AnyAction,
+): PrivacyState => {
   const newHosts = { ...state.approvedHosts };
   switch (action.type) {
     case 'APPROVE_HOST':

--- a/app/reducers/rpcEvents/index.ts
+++ b/app/reducers/rpcEvents/index.ts
@@ -62,6 +62,8 @@ export interface iEventGroup {
   signingEvent: iEventStage;
 }
 
+export type RpcEventsState = iEventGroup;
+
 /**
  * Initial state of the RPC event flow
  */

--- a/app/reducers/rpcEvents/index.ts
+++ b/app/reducers/rpcEvents/index.ts
@@ -67,7 +67,7 @@ export type RpcEventsState = iEventGroup;
 /**
  * Initial state of the RPC event flow
  */
-const initialState: Readonly<iEventGroup> = {
+export const initialState: Readonly<iEventGroup> = {
   signingEvent: {
     eventStage: RPCStageTypes.IDLE,
     rpcName: '',

--- a/app/reducers/settings/index.ts
+++ b/app/reducers/settings/index.ts
@@ -1,6 +1,20 @@
 import AppConstants from '../../core/AppConstants';
+import { AnyAction } from 'redux';
 
-const initialState = {
+export interface SettingsState {
+  searchEngine: string;
+  primaryCurrency: string;
+  lockTime: number;
+  useBlockieIcon: boolean;
+  hideZeroBalanceTokens: boolean;
+  basicFunctionalityEnabled: boolean;
+  showHexData?: boolean;
+  showCustomNonce?: boolean;
+  showFiatOnTestnets?: boolean;
+  deviceNotificationEnabled?: boolean;
+}
+
+const initialState: SettingsState = {
   searchEngine: AppConstants.DEFAULT_SEARCH_ENGINE,
   primaryCurrency: 'ETH',
   lockTime: -1, // Disabled by default
@@ -9,7 +23,10 @@ const initialState = {
   basicFunctionalityEnabled: true,
 };
 
-const settingsReducer = (state = initialState, action) => {
+const settingsReducer = (
+  state: SettingsState = initialState,
+  action: AnyAction,
+): SettingsState => {
   switch (action.type) {
     case 'SET_SEARCH_ENGINE':
       return {

--- a/app/reducers/settings/index.ts
+++ b/app/reducers/settings/index.ts
@@ -14,7 +14,7 @@ export interface SettingsState {
   deviceNotificationEnabled?: boolean;
 }
 
-const initialState: SettingsState = {
+export const initialState: SettingsState = {
   searchEngine: AppConstants.DEFAULT_SEARCH_ENGINE,
   primaryCurrency: 'ETH',
   lockTime: -1, // Disabled by default

--- a/app/reducers/signatureRequest/index.ts
+++ b/app/reducers/signatureRequest/index.ts
@@ -1,6 +1,6 @@
 import { SecurityAlertResponse } from '../../components/Views/confirmations/legacy/components/BlockaidBanner/BlockaidBanner.types';
 
-interface StateType {
+export interface SignatureRequestState {
   securityAlertResponse?: SecurityAlertResponse;
 }
 
@@ -9,14 +9,14 @@ interface ActionType {
   securityAlertResponse?: SecurityAlertResponse;
 }
 
-const initialState: StateType = {
+const initialState: SignatureRequestState = {
   securityAlertResponse: undefined,
 };
 
 const signatureRequestReducer = (
-  state: StateType = initialState,
+  state: SignatureRequestState = initialState,
   action: ActionType = { type: 'NONE' },
-) => {
+): SignatureRequestState => {
   switch (action.type) {
     case 'SET_SIGNATURE_REQUEST_SECURITY_ALERT_RESPONSE':
       return {

--- a/app/reducers/signatureRequest/index.ts
+++ b/app/reducers/signatureRequest/index.ts
@@ -9,7 +9,7 @@ interface ActionType {
   securityAlertResponse?: SecurityAlertResponse;
 }
 
-const initialState: SignatureRequestState = {
+export const initialState: SignatureRequestState = {
   securityAlertResponse: undefined,
 };
 

--- a/app/reducers/swaps/index.ts
+++ b/app/reducers/swaps/index.ts
@@ -14,36 +14,52 @@ import { getChainFeatureFlags, getSwapsLiveness } from './utils';
 import { allowedTestnetChainIds } from '../../components/UI/Swaps/utils';
 import { NETWORKS_CHAIN_ID } from '../../constants/network';
 import { selectSelectedInternalAccountAddress } from '../../selectors/accountsController';
+import { AnyAction } from 'redux';
 
-// If we are in dev and on a testnet, just use mainnet feature flags,
-// since we don't have feature flags for testnets in the API
-export const getFeatureFlagChainId = (chainId) =>
+export const getFeatureFlagChainId = (chainId: string): string =>
   __DEV__ && allowedTestnetChainIds.includes(chainId)
     ? NETWORKS_CHAIN_ID.MAINNET
     : chainId;
 
-// * Constants
 export const SWAPS_SET_LIVENESS = 'SWAPS_SET_LIVENESS';
 export const SWAPS_SET_HAS_ONBOARDED = 'SWAPS_SET_HAS_ONBOARDED';
 const MAX_TOKENS_WITH_BALANCE = 5;
 
-// * Action Creator
-export const setSwapsLiveness = (chainId, featureFlags) => ({
+interface ChainSwapsState {
+  isLive: boolean;
+  featureFlags?: Record<string, unknown>;
+}
+
+export interface SwapsState {
+  isLive: boolean;
+  hasOnboarded: boolean;
+  featureFlags?: Record<string, unknown>;
+  [chainId: string]: boolean | Record<string, unknown> | undefined;
+}
+
+export const setSwapsLiveness = (
+  chainId: string,
+  featureFlags: Record<string, unknown>,
+) => ({
   type: SWAPS_SET_LIVENESS,
   payload: { chainId, featureFlags },
 });
-export const setSwapsHasOnboarded = (hasOnboarded) => ({
+
+export const setSwapsHasOnboarded = (hasOnboarded: boolean) => ({
   type: SWAPS_SET_HAS_ONBOARDED,
   payload: hasOnboarded,
 });
 
-// * Functions
 
-function addMetadata(chainId, tokens, tokenList) {
+function addMetadata(
+  chainId: string,
+  tokens: unknown[],
+  tokenList: Record<string, { name: string }>,
+): unknown[] {
   if (!isMainnetByChainId(chainId)) {
     return tokens;
   }
-  return tokens.map((token) => {
+  return tokens.map((token: { address: string; name?: string }) => {
     const tokenMetadata = tokenList[safeToChecksumAddress(token.address)];
     if (tokenMetadata) {
       return { ...token, name: tokenMetadata.name };
@@ -53,9 +69,8 @@ function addMetadata(chainId, tokens, tokenList) {
   });
 }
 
-// * Selectors
 const chainIdSelector = selectEvmChainId;
-const swapsStateSelector = (state) => state.swaps;
+const swapsStateSelector = (state: { swaps: SwapsState }) => state.swaps;
 /**
  * Returns the swaps liveness state
  */
@@ -63,12 +78,14 @@ const swapsStateSelector = (state) => state.swaps;
 export const swapsLivenessSelector = createSelector(
   swapsStateSelector,
   chainIdSelector,
-  (swapsState, chainId) => swapsState[chainId]?.isLive || false,
+  (swapsState, chainId) =>
+    (swapsState[chainId] as ChainSwapsState)?.isLive || false,
 );
 
 export const swapsLivenessMultichainSelector = createSelector(
-  [swapsStateSelector, (_state, chainId) => chainId],
-  (swapsState, chainId) => swapsState[chainId]?.isLive || false,
+  [swapsStateSelector, (_state: unknown, chainId: string) => chainId],
+  (swapsState, chainId) =>
+    (swapsState[chainId] as ChainSwapsState)?.isLive || false,
 );
 
 /**
@@ -77,7 +94,9 @@ export const swapsLivenessMultichainSelector = createSelector(
 export const swapsSmartTxFlagEnabled = createSelector(
   swapsStateSelector,
   (swapsState) => {
-    const globalFlags = swapsState.featureFlags;
+    const globalFlags = swapsState.featureFlags as
+      | { smartTransactions?: { mobileActive?: boolean } }
+      | undefined;
     const isEnabled = Boolean(globalFlags?.smartTransactions?.mobileActive);
     return isEnabled;
   },
@@ -88,12 +107,13 @@ export const swapsSmartTxFlagEnabled = createSelector(
  */
 export const selectSwapsChainFeatureFlags = createSelector(
   swapsStateSelector,
-  (_state, transactionChainId) =>
+  (_state: unknown, transactionChainId?: string) =>
     transactionChainId || selectEvmChainId(_state),
   (swapsState, chainId) => ({
-    ...swapsState[chainId].featureFlags,
+    ...(swapsState[chainId] as ChainSwapsState).featureFlags,
     smartTransactions: {
-      ...(swapsState[chainId].featureFlags?.smartTransactions || {}),
+      ...((swapsState[chainId] as ChainSwapsState).featureFlags
+        ?.smartTransactions || {}),
       ...(swapsState.featureFlags?.smartTransactions || {}),
     },
   }),
@@ -108,62 +128,74 @@ export const swapsHasOnboardedSelector = createSelector(
   (swapsState) => swapsState.hasOnboarded,
 );
 
-const selectSwapsControllerState = (state) =>
-  state.engine.backgroundState.SwapsController;
+const selectSwapsControllerState = (state: {
+  engine: { backgroundState: { SwapsController: unknown } };
+}) => state.engine.backgroundState.SwapsController;
 
 /**
  * Returns the swaps tokens from the state
  */
-export const swapsControllerTokens = (state) =>
-  state.engine.backgroundState.SwapsController.tokens;
+export const swapsControllerTokens = (state: {
+  engine: { backgroundState: { SwapsController: { tokens: unknown[] } } };
+}) => state.engine.backgroundState.SwapsController.tokens;
 
 export const selectSwapsApprovalTransaction = createSelector(
   selectSwapsControllerState,
-  (swapsControllerState) => swapsControllerState.approvalTransaction,
+  (swapsControllerState: { approvalTransaction: unknown }) =>
+    swapsControllerState.approvalTransaction,
 );
 export const selectSwapsQuoteValues = createSelector(
   selectSwapsControllerState,
-  (swapsControllerState) => swapsControllerState.quoteValues,
+  (swapsControllerState: { quoteValues: unknown }) =>
+    swapsControllerState.quoteValues,
 );
 export const selectSwapsQuotes = createSelector(
   selectSwapsControllerState,
-  (swapsControllerState) => swapsControllerState.quotes,
+  (swapsControllerState: { quotes: unknown }) => swapsControllerState.quotes,
 );
 export const selectSwapsAggregatorMetadata = createSelector(
   selectSwapsControllerState,
-  (swapsControllerState) => swapsControllerState.aggregatorMetadata,
+  (swapsControllerState: { aggregatorMetadata: unknown }) =>
+    swapsControllerState.aggregatorMetadata,
 );
 export const selectSwapsError = createSelector(
   selectSwapsControllerState,
-  (swapsControllerState) => swapsControllerState.error,
+  (swapsControllerState: { error: unknown }) => swapsControllerState.error,
 );
 export const selectSwapsQuoteRefreshSeconds = createSelector(
   selectSwapsControllerState,
-  (swapsControllerState) => swapsControllerState.quoteRefreshSeconds,
+  (swapsControllerState: { quoteRefreshSeconds: unknown }) =>
+    swapsControllerState.quoteRefreshSeconds,
 );
 export const selectSwapsUsedGasEstimate = createSelector(
   selectSwapsControllerState,
-  (swapsControllerState) => swapsControllerState.usedGasEstimate,
+  (swapsControllerState: { usedGasEstimate: unknown }) =>
+    swapsControllerState.usedGasEstimate,
 );
 export const selectSwapsUsedCustomGas = createSelector(
   selectSwapsControllerState,
-  (swapsControllerState) => swapsControllerState.usedCustomGas,
+  (swapsControllerState: { usedCustomGas: unknown }) =>
+    swapsControllerState.usedCustomGas,
 );
 export const selectSwapsTopAggId = createSelector(
   selectSwapsControllerState,
-  (swapsControllerState) => swapsControllerState.topAggId,
+  (swapsControllerState: { topAggId: unknown }) =>
+    swapsControllerState.topAggId,
 );
 export const selectSwapsPollingCyclesLeft = createSelector(
   selectSwapsControllerState,
-  (swapsControllerState) => swapsControllerState.pollingCyclesLeft,
+  (swapsControllerState: { pollingCyclesLeft: unknown }) =>
+    swapsControllerState.pollingCyclesLeft,
 );
 export const selectSwapsQuotesLastFetched = createSelector(
   selectSwapsControllerState,
-  (swapsControllerState) => swapsControllerState.quotesLastFetched,
+  (swapsControllerState: { quotesLastFetched: unknown }) =>
+    swapsControllerState.quotesLastFetched,
 );
 export const selectSwapsIsInPolling = createSelector(
   selectSwapsControllerState,
-  (swapsControllerState) => swapsControllerState.isInPolling,
+  (swapsControllerState: { isInPolling: unknown }) =>
+    swapsControllerState.isInPolling,
 );
 
 const swapsControllerAndUserTokens = createSelector(
@@ -172,19 +204,33 @@ const swapsControllerAndUserTokens = createSelector(
   (swapsTokens, tokens) => {
     const values = [...(swapsTokens || []), ...(tokens || [])]
       .filter(Boolean)
-      .reduce((map, { hasBalanceError, image, ...token }) => {
-        const key = token.address.toLowerCase();
+      .reduce(
+        (
+          map: Map<
+            string,
+            {
+              occurrences: number;
+              address: string;
+              decimals: number;
+              [key: string]: unknown;
+            }
+          >,
+          { hasBalanceError, image, ...token }: Record<string, unknown>,
+        ) => {
+          const key = (token.address as string).toLowerCase();
 
-        if (!map.has(key)) {
-          map.set(key, {
-            occurrences: 0,
-            ...token,
-            decimals: Number(token.decimals),
-            address: key,
-          });
-        }
-        return map;
-      }, new Map())
+          if (!map.has(key)) {
+            map.set(key, {
+              occurrences: 0,
+              ...token,
+              decimals: Number(token.decimals),
+              address: key,
+            });
+          }
+          return map;
+        },
+        new Map(),
+      )
       .values();
 
     return [...values];
@@ -198,27 +244,41 @@ const swapsControllerAndUserTokensMultichain = createSelector(
   (swapsTokens, allTokens, currentUserAddress) => {
     const allTokensArr = Object.values(allTokens);
     const allUserTokensCrossChains = allTokensArr.reduce(
-      (acc, tokensElement) => {
+      (acc: unknown[], tokensElement: Record<string, unknown>) => {
         const found = tokensElement[currentUserAddress] || [];
-        return [...acc, ...found.flat()];
+        return [...acc, ...(found as unknown[]).flat()];
       },
       [],
     );
     const values = [...(swapsTokens || []), ...(allUserTokensCrossChains || [])]
       .filter(Boolean)
-      .reduce((map, { hasBalanceError, image, ...token }) => {
-        const key = token.address.toLowerCase();
+      .reduce(
+        (
+          map: Map<
+            string,
+            {
+              occurrences: number;
+              address: string;
+              decimals: number;
+              [key: string]: unknown;
+            }
+          >,
+          { hasBalanceError, image, ...token }: Record<string, unknown>,
+        ) => {
+          const key = (token.address as string).toLowerCase();
 
-        if (!map.has(key)) {
-          map.set(key, {
-            occurrences: 0,
-            ...token,
-            decimals: Number(token.decimals),
-            address: key,
-          });
-        }
-        return map;
-      }, new Map())
+          if (!map.has(key)) {
+            map.set(key, {
+              occurrences: 0,
+              ...token,
+              decimals: Number(token.decimals),
+              address: key,
+            });
+          }
+          return map;
+        },
+        new Map(),
+      )
       .values();
     return [...values];
   },
@@ -239,12 +299,14 @@ export const swapsTokensSelector = createSelector(
 
 export const topAssets = createSelector(
   selectSwapsControllerState,
-  (swapsControllerState) => swapsControllerState.topAssets,
+  (swapsControllerState: { topAssets: unknown }) =>
+    swapsControllerState.topAssets,
 );
 
 export const selectChainCache = createSelector(
   selectSwapsControllerState,
-  (swapsControllerState) => swapsControllerState.chainCache,
+  (swapsControllerState: { chainCache: unknown }) =>
+    swapsControllerState.chainCache,
 );
 
 /**
@@ -258,7 +320,7 @@ export const swapsTokensObjectSelector = createSelector(
       return {};
     }
 
-    const result = {};
+    const result: Record<string, undefined> = {};
     for (const token of tokens) {
       result[token.address] = undefined;
     }
@@ -277,9 +339,9 @@ export const swapsTokensMultiChainObjectSelector = createSelector(
       return {};
     }
 
-    const result = {};
+    const result: Record<string, undefined> = {};
     for (const token of tokens) {
-      result[token.address] = undefined;
+      result[(token as { address: string }).address] = undefined;
     }
     return result;
   },
@@ -303,11 +365,15 @@ export const swapsTokensWithBalanceSelector = createSelector(
       .filter(([, balance]) => balance !== 0)
       .sort(([, balanceA], [, balanceB]) => (lte(balanceB, balanceA) ? -1 : 1))
       .map(([address]) => address.toLowerCase());
-    const tokensWithBalance = [];
-    const originalTokens = [];
+    const tokensWithBalance: unknown[] = [];
+    const originalTokens: unknown[] = [];
 
     for (let i = 0; i < baseTokens.length; i++) {
-      if (tokensAddressesWithBalance.includes(baseTokens[i].address)) {
+      if (
+        tokensAddressesWithBalance.includes(
+          (baseTokens[i] as { address: string }).address,
+        )
+      ) {
         tokensWithBalance.push(baseTokens[i]);
       } else {
         originalTokens.push(baseTokens[i]);
@@ -343,17 +409,18 @@ export const swapsTopAssetsSelector = createSelector(
     if (!topAssets || !tokens) {
       return [];
     }
-    const result = topAssets
+    const result = (topAssets as { address: string }[])
       .map(({ address }) =>
-        tokens?.find((token) => toLowerCaseEquals(token.address, address)),
+        tokens?.find((token: { address: string }) =>
+          toLowerCaseEquals(token.address, address),
+        ),
       )
       .filter(Boolean);
     return addMetadata(chainId, result, tokenList);
   },
 );
 
-// * Reducer
-export const initialState = {
+export const initialState: SwapsState = {
   isLive: true, // TODO: should we remove it?
   hasOnboarded: true, // TODO: Once we have updated UI / content for the modal, we should enable it again.
 
@@ -364,15 +431,18 @@ export const initialState = {
   },
 };
 
-function swapsReducer(state = initialState, action) {
+function swapsReducer(
+  state: SwapsState = initialState,
+  action: AnyAction,
+): SwapsState {
   switch (action.type) {
     case SWAPS_SET_LIVENESS: {
       const { chainId: rawChainId, featureFlags } = action.payload;
       const chainId = getFeatureFlagChainId(rawChainId);
 
-      const data = state[chainId];
+      const data = state[chainId] as ChainSwapsState | undefined;
 
-      const chainNoFlags = {
+      const chainNoFlags: ChainSwapsState = {
         ...data,
         featureFlags: undefined,
         isLive: false,
@@ -390,7 +460,7 @@ function swapsReducer(state = initialState, action) {
       const chainFeatureFlags = getChainFeatureFlags(featureFlags, chainId);
       const liveness = getSwapsLiveness(featureFlags, chainId);
 
-      const chain = {
+      const chain: ChainSwapsState = {
         ...data,
         featureFlags: chainFeatureFlags,
         isLive: liveness,

--- a/app/reducers/transaction/index.ts
+++ b/app/reducers/transaction/index.ts
@@ -43,7 +43,7 @@ export interface TransactionState {
   maxValueMode?: boolean;
 }
 
-const initialState: TransactionState = {
+export const initialState: TransactionState = {
   ensRecipient: undefined,
   assetType: undefined,
   selectedAsset: {},

--- a/app/reducers/transaction/index.ts
+++ b/app/reducers/transaction/index.ts
@@ -2,6 +2,29 @@ import { REHYDRATE } from 'redux-persist';
 import { getTxData, getTxMeta } from '../../util/transaction-reducer-helpers';
 import { AnyAction } from 'redux';
 
+const normalizeTxValue = (value: unknown): string | undefined => {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === 'string') return value;
+  if (value && typeof (value as any).toString === 'function') {
+    return (value as any).toString(10);
+  }
+  return undefined;
+};
+
+const normalizeTxData = (txData: any): Partial<TransactionObject> => {
+  if (!txData) return {};
+  return {
+    data: txData.data,
+    from: txData.from,
+    gas: normalizeTxValue(txData.gas),
+    gasPrice: normalizeTxValue(txData.gasPrice),
+    to: txData.to,
+    value: normalizeTxValue(txData.value),
+    maxFeePerGas: normalizeTxValue(txData.maxFeePerGas),
+    maxPriorityFeePerGas: normalizeTxValue(txData.maxPriorityFeePerGas),
+  };
+};
+
 export interface TransactionObject {
   data?: string;
   from?: string;
@@ -151,7 +174,7 @@ const transactionReducer = (
         ...state,
         transaction: {
           ...state.transaction,
-          ...getTxData(action.transaction),
+          ...normalizeTxData(getTxData(action.transaction)),
         },
         ...txMeta,
         securityAlertResponses: state.securityAlertResponses,
@@ -173,7 +196,7 @@ const transactionReducer = (
         assetType: 'ETH',
         selectedAsset: { isETH: true, symbol: 'ETH' },
         ...getTxMeta(action.transaction),
-        transaction: getTxData(action.transaction),
+        transaction: normalizeTxData(getTxData(action.transaction)),
       };
     case 'SET_TRANSACTION_SECURITY_ALERT_RESPONSE': {
       const { transactionId, securityAlertResponse } = action;

--- a/app/reducers/transaction/index.ts
+++ b/app/reducers/transaction/index.ts
@@ -1,7 +1,49 @@
 import { REHYDRATE } from 'redux-persist';
 import { getTxData, getTxMeta } from '../../util/transaction-reducer-helpers';
+import { AnyAction } from 'redux';
 
-const initialState = {
+export interface TransactionObject {
+  data?: string;
+  from?: string;
+  gas?: string;
+  gasPrice?: string;
+  to?: string;
+  value?: string;
+  maxFeePerGas?: string;
+  maxPriorityFeePerGas?: string;
+}
+
+export interface SelectedAsset {
+  address?: string;
+  symbol?: string;
+  decimals?: number;
+  tokenId?: string;
+  isETH?: boolean;
+}
+
+export interface TransactionState {
+  ensRecipient?: string;
+  assetType?: string;
+  selectedAsset: SelectedAsset;
+  transaction: TransactionObject;
+  warningGasPriceHigh?: string;
+  transactionTo?: string;
+  transactionToName?: string;
+  transactionFromName?: string;
+  transactionValue?: string;
+  symbol?: string;
+  paymentRequest?: unknown;
+  readableValue?: string;
+  id?: string;
+  type?: string;
+  proposedNonce?: string;
+  nonce?: string;
+  securityAlertResponses: Record<string, unknown>;
+  useMax: boolean;
+  maxValueMode?: boolean;
+}
+
+const initialState: TransactionState = {
   ensRecipient: undefined,
   assetType: undefined,
   selectedAsset: {},
@@ -12,7 +54,6 @@ const initialState = {
     gasPrice: undefined,
     to: undefined,
     value: undefined,
-    // eip1559
     maxFeePerGas: undefined,
     maxPriorityFeePerGas: undefined,
   },
@@ -32,7 +73,7 @@ const initialState = {
   useMax: false,
 };
 
-const getAssetType = (selectedAsset) => {
+const getAssetType = (selectedAsset: SelectedAsset): string | undefined => {
   let assetType;
   if (selectedAsset) {
     if (selectedAsset.tokenId) {
@@ -46,7 +87,10 @@ const getAssetType = (selectedAsset) => {
   return assetType;
 };
 
-const transactionReducer = (state = initialState, action) => {
+const transactionReducer = (
+  state: TransactionState = initialState,
+  action: AnyAction,
+): TransactionState => {
   switch (action.type) {
     case REHYDRATE:
       return {
@@ -110,7 +154,6 @@ const transactionReducer = (state = initialState, action) => {
           ...getTxData(action.transaction),
         },
         ...txMeta,
-        // Retain the securityAlertResponses from the old state
         securityAlertResponses: state.securityAlertResponses,
       };
     }

--- a/app/reducers/wizard/index.ts
+++ b/app/reducers/wizard/index.ts
@@ -1,10 +1,18 @@
 import { REHYDRATE } from 'redux-persist';
+import { AnyAction } from 'redux';
 
-const initialState = {
+export interface WizardState {
+  step: number;
+}
+
+const initialState: WizardState = {
   step: 0,
 };
 
-const onboardingWizardReducer = (state = initialState, action) => {
+const onboardingWizardReducer = (
+  state: WizardState = initialState,
+  action: AnyAction,
+): WizardState => {
   switch (action.type) {
     case REHYDRATE:
       return {

--- a/app/reducers/wizard/index.ts
+++ b/app/reducers/wizard/index.ts
@@ -5,7 +5,7 @@ export interface WizardState {
   step: number;
 }
 
-const initialState: WizardState = {
+export const initialState: WizardState = {
   step: 0,
 };
 

--- a/app/selectors/browser.ts
+++ b/app/selectors/browser.ts
@@ -14,5 +14,5 @@ export const selectBrowserHistoryWithType = createDeepEqualSelector(
 
 export const selectBrowserBookmarksWithType = createDeepEqualSelector(
     (state: RootState) => state.bookmarks,
-    (bookmarks: SiteItem[]) => bookmarks.map(item => ({...item, category: UrlAutocompleteCategory.Favorites} as const))
+    (bookmarks) => bookmarks.map(item => ({url: item.url, name: item.name || '', category: UrlAutocompleteCategory.Favorites} as const))
 );

--- a/app/selectors/confirmTransaction.ts
+++ b/app/selectors/confirmTransaction.ts
@@ -11,7 +11,7 @@ export const selectCurrentTransactionSecurityAlertResponse = (
   state: RootState,
 ) => {
   const { id, securityAlertResponses } = state.transaction;
-  return securityAlertResponses?.[id];
+  return id ? securityAlertResponses?.[id] : undefined;
 };
 
 export const selectCurrentTransactionMetadata = createSelector(

--- a/app/selectors/settings.ts
+++ b/app/selectors/settings.ts
@@ -5,27 +5,27 @@ const selectSettings = (state: RootState) => state.settings;
 
 export const selectShowFiatInTestnets = createSelector(
   selectSettings,
-  (settingsState: Record<string, unknown>) =>
+  (settingsState) =>
     settingsState.showFiatOnTestnets as boolean,
 );
 
 export const selectPrimaryCurrency = createSelector(
   selectSettings,
-  (settingsState: Record<string, unknown>) => settingsState.primaryCurrency,
+  (settingsState) => settingsState.primaryCurrency,
 );
 export const selectShowCustomNonce = createSelector(
   selectSettings,
-  (settingsState: Record<string, unknown>) => settingsState.showCustomNonce,
+  (settingsState) => settingsState.showCustomNonce,
 );
 
 export const selectBasicFunctionalityEnabled = createSelector(
   selectSettings,
-  (settingsState: Record<string, unknown>) =>
+  (settingsState) =>
     settingsState.basicFunctionalityEnabled as boolean,
 );
 
 export const selectHideZeroBalanceTokens = createSelector(
   selectSettings,
-  (settingsState: Record<string, unknown>) =>
+  (settingsState) =>
     Boolean(settingsState.hideZeroBalanceTokens),
 );

--- a/app/store/migrations/064.ts
+++ b/app/store/migrations/064.ts
@@ -31,7 +31,7 @@ export default async function migrate(stateAsync: unknown) {
   if (
     !isValidNetworkControllerState(
       networkControllerState,
-      state as RootState,
+      state as unknown as RootState,
       migrationVersion,
     )
   ) {

--- a/app/util/test/initial-root-state.ts
+++ b/app/util/test/initial-root-state.ts
@@ -80,3 +80,34 @@ if (isTest) {
 }
 
 export default initialRootState;
+
+export type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
+};
+
+function deepMerge<T>(base: T, overrides?: DeepPartial<T>): T {
+  if (!overrides) return base;
+  if (typeof base !== 'object' || base === null) return base;
+  if (Array.isArray(base)) return (overrides as T) ?? base;
+
+  const result = { ...base };
+  for (const key in overrides) {
+    if (Object.prototype.hasOwnProperty.call(overrides, key)) {
+      const overrideValue = overrides[key];
+      const baseValue = base[key];
+      
+      if (overrideValue !== undefined) {
+        if (typeof baseValue === 'object' && baseValue !== null && !Array.isArray(baseValue) &&
+            typeof overrideValue === 'object' && overrideValue !== null && !Array.isArray(overrideValue)) {
+          (result as any)[key] = deepMerge(baseValue, overrideValue as any);
+        } else {
+          (result as any)[key] = overrideValue;
+        }
+      }
+    }
+  }
+  return result;
+}
+
+export const buildInitialRootState = (overrides?: DeepPartial<RootState>): RootState => 
+  deepMerge(initialRootState, overrides);

--- a/app/util/test/initial-root-state.ts
+++ b/app/util/test/initial-root-state.ts
@@ -11,6 +11,23 @@ import { userInitialState } from '../../reducers/user';
 import { initialNavigationState } from '../../reducers/navigation';
 import { initialOnboardingState } from '../../reducers/onboarding';
 import { initialState as initialPerformanceState } from '../../core/redux/slices/performance';
+import { initialState as initialWizardState } from '../../reducers/wizard';
+import { initialState as initialPrivacyState } from '../../reducers/privacy';
+import { initialState as initialBookmarksState } from '../../reducers/bookmarks';
+import { initialState as initialBrowserState } from '../../reducers/browser';
+import { initialState as initialModalsState } from '../../reducers/modals';
+import { initialState as initialSettingsState } from '../../reducers/settings';
+import { initialState as initialAlertState } from '../../reducers/alert';
+import { initialState as initialTransactionState } from '../../reducers/transaction';
+import { initialState as initialNotificationState } from '../../reducers/notification';
+import { initialState as initialSwapsState } from '../../reducers/swaps';
+import { initialState as initialCollectiblesState } from '../../reducers/collectibles';
+import { initialState as initialInfuraAvailabilityState } from '../../reducers/infuraAvailability';
+import { initialState as initialAccountsState } from '../../reducers/accounts';
+import { initialState as initialRpcEventsState } from '../../reducers/rpcEvents';
+import { initialState as initialNetworkSelectorState } from '../../reducers/networkSelector';
+import { initialState as initialExperimentalSettingsState } from '../../reducers/experimentalSettings';
+import { initialState as initialSignatureRequestState } from '../../reducers/signatureRequest';
 import { isTest } from './utils';
 // A cast is needed here because we use enums in some controllers, and TypeScript doesn't consider
 // the string value of an enum as satisfying an enum type.
@@ -19,34 +36,34 @@ export const backgroundState: EngineState =
 
 const initialRootState: RootState = {
   legalNotices: undefined,
-  collectibles: undefined,
+  collectibles: initialCollectiblesState,
   engine: { backgroundState },
-  privacy: undefined,
-  bookmarks: undefined,
-  browser: undefined,
-  modals: undefined,
-  settings: undefined,
-  alert: undefined,
-  transaction: undefined,
+  privacy: initialPrivacyState,
+  bookmarks: initialBookmarksState,
+  browser: initialBrowserState,
+  modals: initialModalsState,
+  settings: initialSettingsState,
+  alert: initialAlertState,
+  transaction: initialTransactionState,
   user: userInitialState,
-  wizard: undefined,
+  wizard: initialWizardState,
   onboarding: initialOnboardingState,
-  notification: undefined,
-  swaps: undefined,
+  notification: initialNotificationState,
+  swaps: initialSwapsState,
   fiatOrders: initialFiatOrdersState,
-  infuraAvailability: undefined,
+  infuraAvailability: initialInfuraAvailabilityState,
   navigation: initialNavigationState,
-  networkOnboarded: undefined,
+  networkOnboarded: initialNetworkSelectorState,
   security: initialSecurityState,
-  signatureRequest: undefined,
+  signatureRequest: initialSignatureRequestState,
   sdk: {
     connections: {},
     approvedHosts: {},
     dappConnections: {},
   },
-  experimentalSettings: undefined,
-  rpcEvents: undefined,
-  accounts: undefined,
+  experimentalSettings: initialExperimentalSettingsState,
+  rpcEvents: initialRpcEventsState,
+  accounts: initialAccountsState,
   inpageProvider: initialInpageProvider,
   confirmationMetrics,
   originThrottling,

--- a/app/util/test/initial-root-state.ts
+++ b/app/util/test/initial-root-state.ts
@@ -28,6 +28,7 @@ import { initialState as initialRpcEventsState } from '../../reducers/rpcEvents'
 import { initialState as initialNetworkSelectorState } from '../../reducers/networkSelector';
 import { initialState as initialExperimentalSettingsState } from '../../reducers/experimentalSettings';
 import { initialState as initialSignatureRequestState } from '../../reducers/signatureRequest';
+import { initialState as initialLegalNoticesState } from '../../reducers/legalNotices';
 import { isTest } from './utils';
 // A cast is needed here because we use enums in some controllers, and TypeScript doesn't consider
 // the string value of an enum as satisfying an enum type.
@@ -35,7 +36,7 @@ export const backgroundState: EngineState =
   initialBackgroundState as unknown as EngineState;
 
 const initialRootState: RootState = {
-  legalNotices: undefined,
+  legalNotices: initialLegalNoticesState,
   collectibles: initialCollectiblesState,
   engine: { backgroundState },
   privacy: initialPrivacyState,


### PR DESCRIPTION
# chore(js-ts): Complete TypeScript migration for Redux reducers and components

## Summary

This PR completes the TypeScript migration for Redux reducers and components by:

1. **Converting 12 JavaScript reducer files to TypeScript** with proper type definitions:
   - `wizard`, `privacy`, `bookmarks`, `browser`, `modals`, `settings`, `alert`
   - `transaction`, `notification`, `swaps`, `collectibles`, `infuraAvailability`

2. **Adding proper state type exports** to existing TypeScript reducers:
   - `accounts`, `rpcEvents`, `networkSelector`, `experimentalSettings`, `signatureRequest`

3. **Updating the root state interface** in `app/reducers/index.ts` to use proper types instead of `any` for all reducers

4. **Fixing component TypeScript TODOs**:
   - Removed `any` type casts for `Identicon` in `Account.tsx`
   - Removed `any` type casts for `Title` in `LoadingAnimation/index.tsx`
   - Properly typed `onAnimationEnd` callback return type as `void`

5. **Resolving BrowserTab type conflict**:
   - Removed duplicate `BrowserTab` interface from `Tokens/types.ts` (had `id: string`)
   - Updated imports to use the correct `BrowserTab` type from browser reducer (has `id: number`)

## Review & Testing Checklist for Human

⚠️ **Risk Level: YELLOW** - This PR touches core state management and has not been manually tested end-to-end.

- [ ] **Verify app launches and basic wallet functionality works** - The changes are type-level only, but could expose existing bugs
- [ ] **Test browser tab functionality** - I resolved a `BrowserTab` type conflict by removing a duplicate type definition. Verify that opening/closing browser tabs and navigating to dApps works correctly
- [ ] **Test NFT/collectibles functionality** - I added null checks in collectibles reducer selectors that could potentially change behavior if `address` or `chainId` are ever undefined
- [ ] **Test token swaps** - The swaps reducer had complex typing changes with some `unknown` types used. Verify swap quotes and execution work correctly
- [ ] **Review TypeScript types** - Some types use `unknown` or `Record<string, unknown>` which might not be ideal. Consider if these can be more specific

### Test Plan

1. Launch the app and verify it starts without errors
2. Navigate through main screens (Wallet, Browser, Activity, Settings)
3. Open a browser tab and visit a dApp
4. View NFTs/collectibles in the wallet
5. Attempt a token swap (at least get quotes)
6. Run `yarn lint:tsc` to verify TypeScript compilation passes (should have 141 errors, same as main branch)

### Notes

- TypeScript error count remains at 141 (same as main branch), confirming no new type errors were introduced
- All changes maintain existing functionality - this is purely a type safety improvement
- The `@typescript-eslint/no-explicit-any` rule is enforced as an error for `.ts`/`.tsx` files, so all new TypeScript code must use proper types

**Link to Devin run**: https://app.devin.ai/sessions/186d61bd4da04c5ebce230bf640ba68f  
**Requested by**: Priya Padmanabhan (@priya-cognition)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates Redux reducers/selectors and related UI to TypeScript with proper state typings, updates RootState, removes unsafe casts, and unifies BrowserTab type usage.
> 
> - **Redux/State (TypeScript migration)**:
>   - Add explicit state interfaces and `AnyAction` typing across reducers: `accounts`, `alert`, `bookmarks`, `browser`, `collectibles`, `experimentalSettings`, `infuraAvailability`, `modals`, `networkSelector`, `notification`, `privacy`, `settings`, `signatureRequest`, `swaps`, `transaction`, `wizard`.
>   - Strengthen selectors with typed params/returns (e.g., `collectibles`, `swaps`, `infuraAvailability`).
>   - Update `app/reducers/index.ts` `RootState` to concrete types; wire reducers with typed exports.
> - **Swaps**:
>   - Define `SwapsState`/`ChainSwapsState`, type action payloads, and ensure selectors handle `unknown` safely; minor logic guard tweaks in token/metadata helpers.
> - **Browser/Types**:
>   - Define `BrowserState` and `BrowserTab` (`id: number`) in `reducers/browser`; remove duplicate `BrowserTab` from `UI/Tokens/types.ts` and update imports in `StakeButton` and `PortfolioBalance`.
> - **Components (type cleanups)**:
>   - `Ramp/Account.tsx`: use `Identicon` directly (remove cast), retain props.
>   - `Ramp/LoadingAnimation`: import `Title` directly; type `onAnimationEnd?: () => void`.
>   - `StakeButton`: import `BrowserTab` from `reducers/browser`.
> - **Misc**:
>   - Minor selector null-checks and address/chain guards to avoid undefined access.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f69349c1b0ae4b3fdfdad74152c3e04f6b32ff4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->