### PR TITLE
test: migrate app/util/test/ganache.js to TypeScript

### DIFF
--- a/app/util/test/ganache.ts
+++ b/app/util/test/ganache.ts
@@ -1,5 +1,9 @@
 import { getGanachePort } from '../../../e2e/fixtures/utils';
-import ganache from 'ganache';
+import ganache, {
+  EthereumProvider,
+  Server,
+  ServerOptions,
+} from 'ganache';
 
 export const DEFAULT_GANACHE_PORT = 8545;
 
@@ -13,35 +17,45 @@ const defaultOptions = {
 };
 
 export default class Ganache {
-  async start(opts) {
+  #server: Server | undefined;
+
+  async start(opts: ServerOptions & { mnemonic?: string }): Promise<void> {
     if (!opts.mnemonic) {
       throw new Error('Missing required mnemonic');
     }
     const options = { ...defaultOptions, ...opts, port: getGanachePort() };
     const { port } = options;
     try {
-      this._server = ganache.server(options);
-      await this._server.listen(port);
+      this.#server = ganache.server(options);
+      await this.#server.listen(port);
     } catch (error) {
       console.error(error);
       throw error;
     }
   }
 
-  getProvider() {
-    return this._server?.provider;
+  getProvider(): EthereumProvider | undefined {
+    return this.#server?.provider;
   }
 
-  async getAccounts() {
-    return await this.getProvider().request({
+  #getRunningProvider(): EthereumProvider {
+    const provider = this.getProvider();
+    if (!provider) {
+      throw new Error('Server not running yet');
+    }
+    return provider;
+  }
+
+  async getAccounts(): Promise<string[]> {
+    return await this.#getRunningProvider().request({
       method: 'eth_accounts',
       params: [],
     });
   }
 
-  async getBalance() {
+  async getBalance(): Promise<number | string> {
     const accounts = await this.getAccounts();
-    const balanceHex = await this.getProvider().request({
+    const balanceHex = await this.#getRunningProvider().request({
       method: 'eth_getBalance',
       params: [accounts[0], 'latest'],
     });
@@ -53,11 +67,11 @@ export default class Ganache {
     return balanceFormatted;
   }
 
-  async quit() {
-    if (!this._server) {
+  async quit(): Promise<void> {
+    if (!this.#server) {
       throw new Error('Server not running yet');
     }
-    await this._server.close();
-    this._server = undefined;
+    await this.#server.close();
+    this.#server = undefined;
   }
 }


### PR DESCRIPTION
## Summary

Migrates `app/util/test/ganache.js` from JavaScript to TypeScript (`ganache.ts`).

Key changes:
- Added typed imports: `Server`, `ServerOptions`, `EthereumProvider` from `ganache`
- Converted `_server` to a true private field (`#server: Server | undefined`)
- Added return types on all methods (`Promise<void>`, `Promise<string[]>`, `Promise<number | string>`, `EthereumProvider | undefined`)
- Typed the `start` parameter as `ServerOptions & { mnemonic?: string }`
- Introduced a private `#getRunningProvider()` helper instead of non-null assertions (which are banned by the project's eslint config) to safely access the provider with a clear error message
- Preserved all original behavior and public API surface (`DEFAULT_GANACHE_PORT`, `start`, `getProvider`, `getAccounts`, `getBalance`, `quit`)

## Review & Testing Checklist for Human

- [ ] Verify that existing callers (`e2e/fixtures/fixture-helper.js`, `wdio/utils/ganache.js`, `e2e/fixtures/utils.js`) still resolve the import correctly. These files import from `../../app/util/test/ganache` without an extension, so both bundlers (Metro/Babel) and Node/tsc should resolve `.ts` over `.js` without changes.
- [ ] Verify no runtime behavior difference by running a local Ganache-based e2e test (e.g., via Detox/WDIO) that exercises `start`, `getProvider`, `getAccounts`, `getBalance`, and `quit`.

### Notes

- **Type verification**: Compiled cleanly against real `ganache@7.9.2` types under `strict: true` TypeScript settings matching the project's `tsconfig.json`.
- **Lint verification**: Passed eslint using the project's TS override rules (the only lint error observed is a preexisting config-level issue with `@typescript-eslint/no-parameter-properties`, which also fires on existing committed `.ts` files like `network.ts`).
- The 55 preexisting tsc errors in the repo are all in unrelated files — none in `ganache.ts`.

Link to Devin session: https://app.devin.ai/sessions/4622c502404d4462ae707f7d797f0240
Requested by: @shayanshafii
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/metamask-mobile/pull/735?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/metamask-mobile/pull/735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/metamask-mobile/pull/735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->