### PR TITLE
refactor: migrate ActivityView component from JavaScript to TypeScript

### DIFF
--- a/app/components/Views/ActivityView/index.tsx
+++ b/app/components/Views/ActivityView/index.tsx
@@ -1,7 +1,14 @@
 import React, { useEffect, useCallback, useRef } from 'react';
-import { View, StyleSheet, Text } from 'react-native';
+import {
+  View,
+  StyleSheet,
+  Text as RNText,
+  TextProps,
+  TextStyle,
+} from 'react-native';
 import ScrollableTabView from 'react-native-scrollable-tab-view';
 import { useSelector } from 'react-redux';
+import { RootState } from '../../../reducers';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { isNonEvmAddress } from '../../../core/Multichain/utils';
 import { getHasOrders } from '../../../reducers/fiatOrders';
@@ -39,8 +46,29 @@ import {
   getFontFamily,
   TextVariant,
 } from '../../../component-library/components/Texts/Text';
+import { Theme } from '../../../util/theme/models';
 
-const createStyles = (params) => {
+interface ActivityViewStyleSheetParams {
+  theme: Theme;
+}
+
+interface TabChildProps {
+  tabLabel: string;
+}
+
+// React Native's Text does not type the `variant` prop, but it is passed here
+// to preserve the existing rendered output.
+const Text = RNText as React.ComponentType<
+  TextProps & { variant?: TextVariant }
+>;
+
+const TransactionsTab =
+  TransactionsView as unknown as React.ComponentType<TabChildProps>;
+const MultichainTransactionsTab =
+  MultichainTransactionsView as React.ComponentType<TabChildProps>;
+const RampOrdersTab = RampOrdersList as React.ComponentType<TabChildProps>;
+
+const createStyles = (params: ActivityViewStyleSheetParams) => {
   const { theme } = params;
   const { colors } = theme;
   return StyleSheet.create({
@@ -81,10 +109,9 @@ const createStyles = (params) => {
       paddingHorizontal: 16,
     },
     title: {
+      ...(typography.sHeadingMD as TextStyle),
       marginTop: 20,
-      fontSize: 20,
       color: colors.text.default,
-      ...typography.sHeadingMD,
       fontFamily: getFontFamily(TextVariant.HeadingMD),
     },
     titleText: {
@@ -111,10 +138,14 @@ const ActivityView = () => {
   const isPopularNetwork = useSelector(selectIsPopularNetwork);
   const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
   const networkName = useSelector(selectNetworkName);
-  const hasOrders = useSelector((state) => getHasOrders(state) || false);
+  const hasOrders = useSelector(
+    (state: RootState) => getHasOrders(state) || false,
+  );
   const accountsByChainId = useSelector(selectAccountsByChainId);
-  const tabViewRef = useRef();
-  const params = useParams();
+  const tabViewRef = useRef<
+    ScrollableTabView & { goToPage: (pageNumber: number) => void }
+  >(null);
+  const params = useParams<{ redirectToOrders?: boolean }>();
 
   const isTestnetOrNotPopularNetwork =
     isTestNet(currentChainId) || !isPopularNetwork;
@@ -128,7 +159,9 @@ const ActivityView = () => {
       createEventBuilder(MetaMetricsEvents.BROWSER_OPEN_ACCOUNT_SWITCH)
         .addProperties({
           number_of_accounts: Object.keys(
-            accountsByChainId[selectedAddress] ?? {},
+            (selectedAddress
+              ? accountsByChainId[selectedAddress]
+              : undefined) ?? {},
           ).length,
         })
         .build(),
@@ -212,14 +245,14 @@ const ActivityView = () => {
           locked={!hasOrders}
         >
           {selectedAddress && isNonEvmAddress(selectedAddress) ? (
-            <MultichainTransactionsView
+            <MultichainTransactionsTab
               tabLabel={strings('transactions_view.title')}
             />
           ) : (
-            <TransactionsView tabLabel={strings('transactions_view.title')} />
+            <TransactionsTab tabLabel={strings('transactions_view.title')} />
           )}
           {hasOrders && (
-            <RampOrdersList
+            <RampOrdersTab
               tabLabel={strings('fiat_on_ramp_aggregator.orders')}
             />
           )}


### PR DESCRIPTION
## Summary

Migrates `app/components/Views/ActivityView/index.js` to TypeScript (`index.tsx`). This is a type-only migration — no runtime logic or UI behavior was changed. The existing snapshot test (`index.test.tsx`) passes without regeneration, confirming the rendered output is unchanged.

Changes:
- Renamed `index.js` → `index.tsx` (git detects an 84% similarity rename).
- Typed `createStyles` with an `ActivityViewStyleSheetParams { theme: Theme }` interface (matching the `useStyles` pattern used elsewhere in the repo).
- Typed `useSelector` callbacks with `RootState` (e.g. `getHasOrders`).
- Typed `useRef` for the `ScrollableTabView` ref so `goToPage` is callable, and typed `useParams<{ redirectToOrders?: boolean }>()`.
- Cast `typography.sHeadingMD` to `TextStyle` in the `title` style (same approach as `Wallet/index.tsx`) and dropped the dead `fontSize: 20` that was already overwritten by the spread.
- Guarded the `accountsByChainId[selectedAddress]` index access since `selectedAddress` can be `undefined`.
- Added typed component aliases for the tab children (`TransactionsView`, `MultichainTransactionsView`, `RampOrdersList`) so the `tabLabel` prop consumed by `ScrollableTabView` type-checks. `TransactionsView` is an untyped connected JS component, so it required a cast.
- Kept React Native's `Text` for the header title and added a local typed alias so the existing `variant` prop still type-checks, preserving the exact rendered output (the snapshot records `variant="sHeadingSM"` on a plain `<Text>`).

## Review & Testing Checklist for Human

- [ ] Confirm the `variant` prop handling on the header `Text` is acceptable — it's preserved as-is for behavior parity, but note that React Native's `Text` ignores `variant` at runtime (the upstream MetaMask version uses the component-library `Text`). A follow-up could switch to the component-library `Text` if the heading style should actually be driven by `variant`.
- [ ] Confirm the casts on the tab children (especially `TransactionsView`, an untyped connected JS component) are acceptable, or whether those child components should instead declare a `tabLabel` prop.
- [ ] Smoke-test the Activity/Transactions screen in the app: tab switching between Transactions and Orders, the network filter button, and the `redirectToOrders` deep-link path that calls `goToPage(1)`.

### Notes

- Verified locally: `tsc --noEmit` reports no errors for this file, `prettier --check` passes, and the `ActivityView` Jest snapshot test passes without changes.
- No changes to test files, `package.json`, or `yarn.lock`.
</body>


Link to Devin session: https://app.devin.ai/sessions/f27d8dc373d247c6ac7e14dd2a3593d5
Requested by: @shayanshafii
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/metamask-mobile/pull/736?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/metamask-mobile/pull/736" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/metamask-mobile/pull/736" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->