### PR TITLE
refactor(test): migrate ganache.js to TypeScript

### DIFF
--- a/app/util/test/ganache.ts
+++ b/app/util/test/ganache.ts
@@ -1,9 +1,23 @@
 import { getGanachePort } from '../../../e2e/fixtures/utils';
-import ganache from 'ganache';
+import ganache, { type Server, type ServerOptions } from 'ganache';
 
 export const DEFAULT_GANACHE_PORT = 8545;
 
-const defaultOptions = {
+/**
+ * Options accepted by the Ganache server. Extends ganache's `ServerOptions`
+ * with the legacy flat option keys that this wrapper relies on at runtime.
+ */
+type GanacheOptions = ServerOptions & {
+  blockTime?: number;
+  network_id?: number;
+  port?: number;
+  vmErrorsOnRPCResponse?: boolean;
+  hardfork?: string;
+  quiet?: boolean;
+  mnemonic?: string;
+};
+
+const defaultOptions: GanacheOptions = {
   blockTime: 2,
   network_id: 1337,
   port: DEFAULT_GANACHE_PORT,
@@ -13,7 +27,9 @@ const defaultOptions = {
 };
 
 export default class Ganache {
-  async start(opts) {
+  private _server: Server | undefined;
+
+  async start(opts: GanacheOptions): Promise<void> {
     if (!opts.mnemonic) {
       throw new Error('Missing required mnemonic');
     }
@@ -32,20 +48,28 @@ export default class Ganache {
     return this._server?.provider;
   }
 
-  async getAccounts() {
-    return await this.getProvider().request({
+  async getAccounts(): Promise<string[]> {
+    const provider = this.getProvider();
+    if (!provider) {
+      throw new Error('Server not running yet');
+    }
+    return await provider.request({
       method: 'eth_accounts',
       params: [],
     });
   }
 
-  async getBalance() {
+  async getBalance(): Promise<number | string> {
+    const provider = this.getProvider();
+    if (!provider) {
+      throw new Error('Server not running yet');
+    }
     const accounts = await this.getAccounts();
-    const balanceHex = await this.getProvider().request({
+    const balanceHex = await provider.request({
       method: 'eth_getBalance',
       params: [accounts[0], 'latest'],
     });
-    const balanceInt = parseInt(balanceHex, 16) / 10 ** 18;
+    const balanceInt = parseInt(String(balanceHex), 16) / 10 ** 18;
 
     const balanceFormatted =
       balanceInt % 1 === 0 ? balanceInt : balanceInt.toFixed(4);
@@ -53,7 +77,7 @@ export default class Ganache {
     return balanceFormatted;
   }
 
-  async quit() {
+  async quit(): Promise<void> {
     if (!this._server) {
       throw new Error('Server not running yet');
     }


### PR DESCRIPTION
## **Description**

Migrates `app/util/test/ganache.js` to TypeScript (`ganache.ts`). This is a type-only refactor — runtime behavior is unchanged. It brings the Ganache test helper in line with its sibling `e2e/seeder/anvil-manager.ts`, which is already TS.

What was added:
- `_server` is now typed as `Server | undefined` (from `ganache`).
- A `GanacheOptions` type extends ganache's exported `ServerOptions` with the legacy flat option keys the wrapper passes at runtime (`blockTime`, `network_id`, `port`, `vmErrorsOnRPCResponse`, `hardfork`, `quiet`, `mnemonic`). ganache's typings only model the nested option shape, so these legacy keys are declared explicitly to keep the existing call shape working.
- `getAccounts()` / `getBalance()` guard `getProvider()` before use (it returns `Provider | undefined`), mirroring the guard pattern in `anvil-manager.ts`, instead of calling `.request` on a possibly-undefined provider.

Note on `getBalance`: ganache types `eth_getBalance` as returning `Quantity`, but the EIP-1193 `request` actually returns a serialized hex `string` at runtime (verified empirically). The original `parseInt(balanceHex, 16)` relies on this, so the value is passed through `String(...)` to satisfy the compiler without changing behavior:

```ts
const balanceHex = await provider.request({
  method: 'eth_getBalance',
  params: [accounts[0], 'latest'],
});
const balanceInt = parseInt(String(balanceHex), 16) / 10 ** 18;
```

## **Related issues**

Fixes:

## **Manual testing steps**

1. `yarn lint:tsc` — the migrated file produces no type errors (preexisting, unrelated errors in the repo are unaffected).
2. The helper is consumed by `e2e/fixtures/fixture-helper.js` and `e2e/fixtures/utils.js`; e2e flows that start a Ganache local node exercise `start`/`getProvider`/`getAccounts`/`getBalance`/`quit`.

## **Screenshots/Recordings**

N/A — no UI changes.

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Link to Devin session: https://app.devin.ai/sessions/b17fa722f5ac4988bc5caa6584fa03e7
Requested by: @shayanshafii
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/metamask-mobile/pull/745?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/metamask-mobile/pull/745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->