### PR TITLE
chore(js-ts): Convert app/util/test/ganache.js to TypeScript

### DIFF
--- a/app/util/test/ganache.ts
+++ b/app/util/test/ganache.ts
@@ -34,8 +34,16 @@ export default class Ganache {
     return this._server?.provider;
   }
 
-  async getAccounts(): Promise<string[] | undefined> {
-    return await this.getProvider()?.request({
+  private getRequiredProvider() {
+    const provider = this.getProvider();
+    if (!provider) {
+      throw new Error('Server not running yet');
+    }
+    return provider;
+  }
+
+  async getAccounts(): Promise<string[]> {
+    return await this.getRequiredProvider().request({
       method: 'eth_accounts',
       params: [],
     });
@@ -43,11 +51,14 @@ export default class Ganache {
 
   async getBalance(): Promise<number | string> {
     const accounts = await this.getAccounts();
-    const balanceHex = await this.getProvider()?.request({
+    if (!accounts?.length) {
+      throw new Error('No accounts available');
+    }
+    const balanceHex = await this.getRequiredProvider().request({
       method: 'eth_getBalance',
-      params: [accounts?.[0] as string, 'latest'],
+      params: [accounts[0], 'latest'],
     });
-    const balanceInt = parseInt(balanceHex as string, 16) / 10 ** 18;
+    const balanceInt = parseInt(balanceHex, 16) / 10 ** 18;
 
     const balanceFormatted =
       balanceInt % 1 === 0 ? balanceInt : balanceInt.toFixed(4);

--- a/app/util/test/ganache.ts
+++ b/app/util/test/ganache.ts
@@ -1,5 +1,5 @@
+import ganache, { Server, ServerOptions } from 'ganache';
 import { getGanachePort } from '../../../e2e/fixtures/utils';
-import ganache from 'ganache';
 
 export const DEFAULT_GANACHE_PORT = 8545;
 
@@ -13,7 +13,9 @@ const defaultOptions = {
 };
 
 export default class Ganache {
-  async start(opts) {
+  private _server?: Server;
+
+  async start(opts: ServerOptions & { mnemonic?: string }): Promise<void> {
     if (!opts.mnemonic) {
       throw new Error('Missing required mnemonic');
     }
@@ -32,20 +34,20 @@ export default class Ganache {
     return this._server?.provider;
   }
 
-  async getAccounts() {
-    return await this.getProvider().request({
+  async getAccounts(): Promise<string[] | undefined> {
+    return await this.getProvider()?.request({
       method: 'eth_accounts',
       params: [],
     });
   }
 
-  async getBalance() {
+  async getBalance(): Promise<number | string> {
     const accounts = await this.getAccounts();
-    const balanceHex = await this.getProvider().request({
+    const balanceHex = await this.getProvider()?.request({
       method: 'eth_getBalance',
-      params: [accounts[0], 'latest'],
+      params: [accounts?.[0] as string, 'latest'],
     });
-    const balanceInt = parseInt(balanceHex, 16) / 10 ** 18;
+    const balanceInt = parseInt(balanceHex as string, 16) / 10 ** 18;
 
     const balanceFormatted =
       balanceInt % 1 === 0 ? balanceInt : balanceInt.toFixed(4);
@@ -53,7 +55,7 @@ export default class Ganache {
     return balanceFormatted;
   }
 
-  async quit() {
+  async quit(): Promise<void> {
     if (!this._server) {
       throw new Error('Server not running yet');
     }


### PR DESCRIPTION
## Summary
Migrates `app/util/test/ganache.js` to TypeScript (`ganache.ts`) with no behavior change. Types come from the `ganache` package itself:

- `_server` is now a typed private field: `private _server?: Server`
- `start(opts: ServerOptions & { mnemonic?: string })` — mnemonic check preserved
- `getProvider()` returns `this._server?.provider`, so `getAccounts()`/`getBalance()` use optional chaining on the provider; return types are `Promise<string[] | undefined>` and `Promise<number | string>` respectively
- `eth_getBalance` response is cast to `string` before `parseInt(..., 16)`

`yarn lint:tsc` reports no errors for this file or its importers (`e2e/fixtures/fixture-helper.js`, `e2e/fixtures/utils.js`, `wdio/utils/ganache.js`); remaining tsc errors are preexisting on `main` in unrelated files.

Link to Devin session: https://app.devin.ai/sessions/6859b1d135454526aca0329f143aafce
Requested by: @shayanshafii
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/metamask-mobile/pull/748?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/metamask-mobile/pull/748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->