### PR TITLE
refactor(test): migrate ganache-seeder from JS to TS

### DIFF
--- a/app/util/test/ganache-seeder.ts
+++ b/app/util/test/ganache-seeder.ts
@@ -1,5 +1,5 @@
-import { Web3Provider } from '@ethersproject/providers';
-import { ContractFactory } from '@ethersproject/contracts';
+import { ExternalProvider, Web3Provider } from '@ethersproject/providers';
+import { Contract, ContractFactory } from '@ethersproject/contracts';
 import { SMART_CONTRACTS, contractConfiguration } from './smart-contracts';
 import ContractAddressRegistry from './contract-address-registry';
 
@@ -7,7 +7,11 @@ import ContractAddressRegistry from './contract-address-registry';
  * Ganache seeder is used to seed initial smart contract or set initial blockchain state.
  */
 class GanacheSeeder {
-  constructor(ganacheProvider) {
+  smartContractRegistry: ContractAddressRegistry;
+
+  ganacheProvider: ExternalProvider;
+
+  constructor(ganacheProvider: ExternalProvider) {
     this.smartContractRegistry = new ContractAddressRegistry();
     this.ganacheProvider = ganacheProvider;
   }
@@ -15,27 +19,30 @@ class GanacheSeeder {
   /**
    * Deploy initial smart contracts that can be used later within the e2e tests.
    *
-   * @param contractName
+   * @param contractName - Name of the contract to deploy.
    */
-
-  async deploySmartContract(contractName) {
+  async deploySmartContract(contractName: string): Promise<void> {
     const ethersProvider = new Web3Provider(this.ganacheProvider, 'any');
     const signer = ethersProvider.getSigner();
     const fromAddress = await signer.getAddress();
+    const contractConfig = contractConfiguration[contractName];
     const contractFactory = new ContractFactory(
-      contractConfiguration[contractName].abi,
-      contractConfiguration[contractName].bytecode,
+      contractConfig.abi,
+      contractConfig.bytecode,
       signer,
     );
 
-    let contract;
+    let contract: Contract;
 
-    if (contractName === SMART_CONTRACTS.HST) {
+    if (
+      contractName === SMART_CONTRACTS.HST &&
+      'initialAmount' in contractConfig
+    ) {
       contract = await contractFactory.deploy(
-        contractConfiguration[SMART_CONTRACTS.HST].initialAmount,
-        contractConfiguration[SMART_CONTRACTS.HST].tokenName,
-        contractConfiguration[SMART_CONTRACTS.HST].decimalUnits,
-        contractConfiguration[SMART_CONTRACTS.HST].tokenSymbol,
+        contractConfig.initialAmount,
+        contractConfig.tokenName,
+        contractConfig.decimalUnits,
+        contractConfig.tokenSymbol,
       );
     } else {
       contract = await contractFactory.deploy();
@@ -66,10 +73,13 @@ class GanacheSeeder {
    * Store deployed smart contract address within the environment variables
    * to make it available everywhere.
    *
-   * @param contractName
-   * @param contractAddress
+   * @param contractName - Name of the deployed contract.
+   * @param contractAddress - Address of the deployed contract.
    */
-  storeSmartContractAddress(contractName, contractAddress) {
+  storeSmartContractAddress(
+    contractName: string,
+    contractAddress: string,
+  ): void {
     this.smartContractRegistry.storeNewContractAddress(
       contractName,
       contractAddress,
@@ -81,7 +91,7 @@ class GanacheSeeder {
    *
    * @returns ContractAddressRegistry
    */
-  getContractRegistry() {
+  getContractRegistry(): ContractAddressRegistry {
     return this.smartContractRegistry;
   }
 }


### PR DESCRIPTION
## **Description**

Migrates `app/util/test/ganache-seeder.js` to TypeScript (`ganache-seeder.ts`) as part of the ongoing JS→TS migration. This is a pure type-annotation pass — **no runtime behavior changes**.

Typing notes worth calling out:

- The class fields and constructor param are typed: `ganacheProvider: ExternalProvider` (from `@ethersproject/providers`), which is what `new Web3Provider(this.ganacheProvider, 'any')` expects. Methods are annotated (`deploySmartContract(contractName: string): Promise<void>`, `storeSmartContractAddress(contractName: string, contractAddress: string): void`, `getContractRegistry(): ContractAddressRegistry`).
- `contractConfiguration[contractName]` infers a **union** of all factory shapes (because `SMART_CONTRACTS` values widen to `string` in `smart-contracts.js`), so the HST-only fields (`initialAmount`, `tokenName`, `decimalUnits`, `tokenSymbol`) aren't accessible on the union. To keep the change scoped to this one file and avoid casts, the entry is captured once and narrowed with an `in` guard, which is runtime-equivalent (the HST config always has `initialAmount`):

  ```ts
  const contractConfig = contractConfiguration[contractName];
  // ...
  if (
    contractName === SMART_CONTRACTS.HST &&
    'initialAmount' in contractConfig
  ) {
    contract = await contractFactory.deploy(
      contractConfig.initialAmount,
      contractConfig.tokenName,
      contractConfig.decimalUnits,
      contractConfig.tokenSymbol,
    );
  } else {
    contract = await contractFactory.deploy();
  }
  ```

- Renamed via `git mv` so history is preserved. The two importers (`wdio/utils/ganache.js`, `e2e/fixtures/fixture-helper.js`) import without a file extension, so they resolve to the new `.ts` file with no changes needed.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. `yarn lint:tsc` — passes; this file introduces no new type errors.
2. `yarn lint` on `app/util/test/ganache-seeder.ts` — passes.

No behavioral change: the seeder deploys the same contracts with the same arguments and the same post-deploy mint calls (`mintNFTs` / `mintBatch`).

## **Screenshots/Recordings**

N/A — internal test/e2e utility, no UI.

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Link to Devin session: https://app.devin.ai/sessions/cd57e980f78c4f30b3892f0740112ccf
Requested by: @shayanshafii
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/metamask-mobile/pull/760?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/metamask-mobile/pull/760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->