### PR TITLE
chore(js-ts): Convert app/util/test/ganache.js to TypeScript

### DIFF
--- a/app/util/test/ganache.ts
+++ b/app/util/test/ganache.ts
@@ -1,5 +1,5 @@
 import { getGanachePort } from '../../../e2e/fixtures/utils';
-import ganache from 'ganache';
+import ganache, { type Provider, type Server, type ServerOptions } from 'ganache';
 
 export const DEFAULT_GANACHE_PORT = 8545;
 
@@ -12,8 +12,12 @@ const defaultOptions = {
   quiet: false,
 };
 
+export type GanacheStartOptions = ServerOptions & { mnemonic?: string };
+
 export default class Ganache {
-  async start(opts) {
+  private _server?: Server;
+
+  async start(opts: GanacheStartOptions): Promise<void> {
     if (!opts.mnemonic) {
       throw new Error('Missing required mnemonic');
     }
@@ -28,24 +32,32 @@ export default class Ganache {
     }
   }
 
-  getProvider() {
+  getProvider(): Provider | undefined {
     return this._server?.provider;
   }
 
-  async getAccounts() {
-    return await this.getProvider().request({
+  async getAccounts(): Promise<string[]> {
+    const provider = this.getProvider();
+    if (!provider) {
+      throw new Error('Server not running yet');
+    }
+    return await provider.request({
       method: 'eth_accounts',
       params: [],
     });
   }
 
-  async getBalance() {
+  async getBalance(): Promise<number | string> {
+    const provider = this.getProvider();
+    if (!provider) {
+      throw new Error('Server not running yet');
+    }
     const accounts = await this.getAccounts();
-    const balanceHex = await this.getProvider().request({
+    const balanceHex = await provider.request({
       method: 'eth_getBalance',
       params: [accounts[0], 'latest'],
     });
-    const balanceInt = parseInt(balanceHex, 16) / 10 ** 18;
+    const balanceInt = parseInt(String(balanceHex), 16) / 10 ** 18;
 
     const balanceFormatted =
       balanceInt % 1 === 0 ? balanceInt : balanceInt.toFixed(4);
@@ -53,7 +65,7 @@ export default class Ganache {
     return balanceFormatted;
   }
 
-  async quit() {
+  async quit(): Promise<void> {
     if (!this._server) {
       throw new Error('Server not running yet');
     }


### PR DESCRIPTION
## Summary

Migrates the Ganache test helper from JS to TS (`app/util/test/ganache.js` → `ganache.ts`), adding types while preserving the public API (`DEFAULT_GANACHE_PORT` and the default-exported `Ganache` class with `start`/`getProvider`/`getAccounts`/`getBalance`/`quit`). Importers (`e2e/fixtures/*`, `wdio/utils/ganache.js`) import without a file extension, so the rename is transparent.

Types are sourced from `ganache`'s own declarations:

```ts
import ganache, { type Provider, type Server, type ServerOptions } from 'ganache';

export type GanacheStartOptions = ServerOptions & { mnemonic?: string };

private _server?: Server;
async start(opts: GanacheStartOptions): Promise<void> { ... }
getProvider(): Provider | undefined { return this._server?.provider; }
```

Two behavior-preserving adaptations were needed for strict mode:
- `getAccounts`/`getBalance` previously called `this.getProvider().request(...)` on a possibly-`undefined` provider. They now guard and `throw new Error('Server not running yet')` when the server isn't running — same throw-on-missing-server semantics already used by `quit()`.
- `ganache`'s `request('eth_getBalance')` is typed as `Quantity` but resolves to a hex string at runtime over the EIP-1193 `request` interface, so `parseInt(balanceHex, 16)` becomes `parseInt(String(balanceHex), 16)` (identity at runtime).

`GanacheStartOptions` adds the legacy flat `mnemonic` (callers pass `{ mnemonic }`); the merged options object (`network_id`, `blockTime`, `hardfork`, …) remains assignable to ganache's all-optional `ServerOptions`.

## Verification

- `tsc --project ./tsconfig.json`: the new `ganache.ts` produces **0 type errors**. The project has 55 pre-existing, unrelated type errors (PreferencesController / NFT / NetworkModal); the count is identical with the original `.js` (55) and with the new `.ts` (55), so this change introduces no new type errors.
- `eslint app/util/test/ganache.ts`: no lint violations in this file. Note there is a repo-wide pre-existing eslint config error (`@typescript-eslint/no-parameter-properties` rule no longer exists in the pinned `@typescript-eslint@7.18.0`) that fires identically on every existing `.ts` file (e.g. `app/util/test/network.ts`).

No functional/runtime changes.

Link to Devin session: https://app.devin.ai/sessions/db820cfbc43842249308cd64378b2649
Requested by: @shayanshafii
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/metamask-mobile/pull/762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->