### PR TITLE
chore(js-ts): Convert app/util/test/ganache.js to TypeScript

### DIFF
--- a/app/util/test/ganache.ts
+++ b/app/util/test/ganache.ts
@@ -1,9 +1,23 @@
 import { getGanachePort } from '../../../e2e/fixtures/utils';
-import ganache from 'ganache';
+import ganache, {
+  type Server,
+  type ServerOptions,
+  type EthereumProvider,
+} from 'ganache';
 
 export const DEFAULT_GANACHE_PORT = 8545;
 
-const defaultOptions = {
+interface GanacheServerOptions {
+  blockTime?: number;
+  network_id?: number;
+  port?: number;
+  vmErrorsOnRPCResponse?: boolean;
+  hardfork?: string;
+  quiet?: boolean;
+  mnemonic?: string;
+}
+
+const defaultOptions: GanacheServerOptions = {
   blockTime: 2,
   network_id: 1337,
   port: DEFAULT_GANACHE_PORT,
@@ -13,14 +27,16 @@ const defaultOptions = {
 };
 
 export default class Ganache {
-  async start(opts) {
+  private _server: Server | undefined;
+
+  async start(opts: GanacheServerOptions): Promise<void> {
     if (!opts.mnemonic) {
       throw new Error('Missing required mnemonic');
     }
     const options = { ...defaultOptions, ...opts, port: getGanachePort() };
     const { port } = options;
     try {
-      this._server = ganache.server(options);
+      this._server = ganache.server(options as unknown as ServerOptions);
       await this._server.listen(port);
     } catch (error) {
       console.error(error);
@@ -28,23 +44,26 @@ export default class Ganache {
     }
   }
 
-  getProvider() {
-    return this._server?.provider;
+  getProvider(): EthereumProvider {
+    if (!this._server) {
+      throw new Error('Server not running yet');
+    }
+    return this._server.provider;
   }
 
-  async getAccounts() {
+  async getAccounts(): Promise<string[]> {
     return await this.getProvider().request({
       method: 'eth_accounts',
       params: [],
     });
   }
 
-  async getBalance() {
+  async getBalance(): Promise<number | string> {
     const accounts = await this.getAccounts();
-    const balanceHex = await this.getProvider().request({
+    const balanceHex = (await this.getProvider().request({
       method: 'eth_getBalance',
       params: [accounts[0], 'latest'],
-    });
+    })) as unknown as string;
     const balanceInt = parseInt(balanceHex, 16) / 10 ** 18;
 
     const balanceFormatted =
@@ -53,7 +72,7 @@ export default class Ganache {
     return balanceFormatted;
   }
 
-  async quit() {
+  async quit(): Promise<void> {
     if (!this._server) {
       throw new Error('Server not running yet');
     }


### PR DESCRIPTION
## **Description**

Migrates `app/util/test/ganache.js` to TypeScript (`ganache.ts`) as part of the ongoing JS→TS conversion effort. This is the `Ganache` local test-node wrapper used by the e2e/wdio fixtures.

Behavior and the public surface are preserved:
- `export const DEFAULT_GANACHE_PORT = 8545;`
- `export default class Ganache` with `start(opts)`, `getProvider()`, `getAccounts()`, `getBalance()`, `quit()`.

Typing notes (the non-obvious parts):
- Imports the `Server`, `ServerOptions`, and `EthereumProvider` types from `ganache`. The private field is typed `private _server: Server | undefined;`, mirroring the existing TS sibling `e2e/seeder/anvil-manager.ts`.
- The wrapper accepts the legacy *flat* ganache options (`blockTime`, `network_id`, `hardfork`, etc.). ganache v7's strict `ServerOptions` type models these under namespaces, so the merged options object is passed via `options as unknown as ServerOptions` to preserve the exact runtime input.
- `getProvider()` now throws `'Server not running yet'` when the server hasn't started (instead of returning `undefined`), matching `anvil-manager.ts` and letting `getAccounts`/`getBalance` typecheck cleanly under `strict`. Callers only ever invoke it after `start()`.
- `getBalance()` casts the `eth_getBalance` result to `string` since the provider returns a hex string at runtime even though the static type is `Quantity`.

## **Related issues**

Fixes:

## **Manual testing steps**

1. `yarn lint:tsc` — typechecks with no new errors (the only error in this environment is the generated `termsOfUseContent.ts`, which CI generates during setup).
2. `yarn lint` on `app/util/test/ganache.ts` passes.

## **Screenshots/Recordings**

N/A — internal test utility, no UI change.

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Link to Devin session: https://app.devin.ai/sessions/969d92072f8a4732af37975cba6dcc32
Requested by: @shayanshafii
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/metamask-mobile/pull/765?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/metamask-mobile/pull/765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/metamask-mobile/pull/765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->