### PR TITLE
refactor: migrate app/util/test/ganache to TypeScript

### DIFF
--- a/app/util/test/ganache.ts
+++ b/app/util/test/ganache.ts
@@ -1,5 +1,5 @@
 import { getGanachePort } from '../../../e2e/fixtures/utils';
-import ganache from 'ganache';
+import ganache, { type Server, type ServerOptions } from 'ganache';
 
 export const DEFAULT_GANACHE_PORT = 8545;
 
@@ -12,16 +12,22 @@ const defaultOptions = {
   quiet: false,
 };
 
+type GanacheServerOptions = ServerOptions & {
+  mnemonic?: string;
+};
+
 export default class Ganache {
-  async start(opts) {
+  #server: Server | undefined;
+
+  async start(opts: GanacheServerOptions): Promise<void> {
     if (!opts.mnemonic) {
       throw new Error('Missing required mnemonic');
     }
     const options = { ...defaultOptions, ...opts, port: getGanachePort() };
     const { port } = options;
     try {
-      this._server = ganache.server(options);
-      await this._server.listen(port);
+      this.#server = ganache.server(options);
+      await this.#server.listen(port);
     } catch (error) {
       console.error(error);
       throw error;
@@ -29,22 +35,26 @@ export default class Ganache {
   }
 
   getProvider() {
-    return this._server?.provider;
+    return this.#server?.provider;
   }
 
-  async getAccounts() {
-    return await this.getProvider().request({
+  async getAccounts(): Promise<string[] | undefined> {
+    return await this.getProvider()?.request({
       method: 'eth_accounts',
       params: [],
     });
   }
 
-  async getBalance() {
+  async getBalance(): Promise<number | string> {
     const accounts = await this.getAccounts();
-    const balanceHex = await this.getProvider().request({
-      method: 'eth_getBalance',
-      params: [accounts[0], 'latest'],
-    });
+    if (!accounts?.length) {
+      return 0;
+    }
+    const balanceHex =
+      (await this.getProvider()?.request({
+        method: 'eth_getBalance',
+        params: [accounts[0], 'latest'],
+      })) ?? '0x0';
     const balanceInt = parseInt(balanceHex, 16) / 10 ** 18;
 
     const balanceFormatted =
@@ -53,11 +63,11 @@ export default class Ganache {
     return balanceFormatted;
   }
 
-  async quit() {
-    if (!this._server) {
+  async quit(): Promise<void> {
+    if (!this.#server) {
       throw new Error('Server not running yet');
     }
-    await this._server.close();
-    this._server = undefined;
+    await this.#server.close();
+    this.#server = undefined;
   }
 }


### PR DESCRIPTION
## **Description**

Migrates the e2e/wdio test helper `app/util/test/ganache.js` to TypeScript (`ganache.ts`), adding static types while preserving runtime behavior. This continues the ongoing JS→TS migration of the codebase and matches the typing style already used by the sibling local-node manager `e2e/seeder/anvil-manager.ts`.

What changed and why it's not a trivial 1:1 rename:

- **Typed the ganache server field** using the library's own types: `import ganache, { type Server, type ServerOptions } from 'ganache'`. The instance field is declared as a private class field `#server: Server | undefined` (the old code relied on an undeclared `this._server`, which isn't allowed under `strict`). Nothing outside the class read `_server`, so the rename to a `#private` field is safe.
- **`start(opts)` parameter type.** ganache v7's `ServerOptions` type does **not** expose the legacy flat `mnemonic` option (it lives under `wallet.mnemonic`), even though it's still accepted at runtime and callers pass it flat. To keep `opts.mnemonic` typed without losing the rest of the options surface:
  ```ts
  type GanacheServerOptions = ServerOptions & { mnemonic?: string };
  async start(opts: GanacheServerOptions): Promise<void> { ... }
  ```
- **Null-safety in `getAccounts`/`getBalance`.** `getProvider()` returns `this.#server?.provider` (possibly `undefined`), and `eth_getBalance` requires a non-optional address. Added a guard so `accounts[0]` is a `string` and defaulted a missing balance to `'0x0'`; logic and the `number | string` formatted result are otherwise identical to the original.

Because imports across the repo are extensionless (`import Ganache from '../../app/util/test/ganache'`), the `.js`→`.ts` rename is transparent to the three importers (`wdio/utils/ganache.js`, `e2e/fixtures/fixture-helper.js`, `e2e/fixtures/utils.js`); no call sites changed.

## **Related issues**

Fixes:

## **Manual testing steps**

This is an e2e/wdio test helper, so it isn't exercised by the Jest unit suite. Verified statically:

1. `yarn lint` on the file passes (after `patch-package` is applied).
2. `tsc --noEmit` reports no type errors for `app/util/test/ganache.ts`.
3. Confirmed the public surface (`DEFAULT_GANACHE_PORT`, default export `Ganache` with `start`/`getProvider`/`getAccounts`/`getBalance`/`quit`) is unchanged, so the three importers resolve without edits.

## **Screenshots/Recordings**

N/A — no user-facing changes.

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


Link to Devin session: https://app.devin.ai/sessions/e9b1624570534c3292a81cd0c0fb5e51
Requested by: @shayanshafii
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/metamask-mobile/pull/775?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/metamask-mobile/pull/775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->