### PR TITLE
fix(security): prevent Zip Slip path traversal in RNTar.java

### DIFF
--- a/android/app/src/main/java/io/metamask/nativeModules/RNTar/RNTar.java
+++ b/android/app/src/main/java/io/metamask/nativeModules/RNTar/RNTar.java
@@ -85,8 +85,15 @@ public class RNTar extends ReactContextBaseJavaModule {
         TarArchiveEntry entry;
 
         // Loop through the entries in the .tgz file
+        String canonicalTarget = new File(outputPath).getCanonicalPath() + File.separator;
         while ((entry = (TarArchiveEntry) tarInputStream.getNextEntry()) != null) {
           File outputFile = new File(outputPath, entry.getName());
+
+          // Validate that the entry does not escape the target directory (Zip Slip protection)
+          String canonicalDest = outputFile.getCanonicalPath();
+          if (!canonicalDest.startsWith(canonicalTarget)) {
+            throw new SecurityException("Entry is outside of the target dir: " + entry.getName());
+          }
 
           // If it is a directory, create the output directory
           if (entry.isDirectory()) {


### PR DESCRIPTION
## Summary

Fixes a **HIGH** severity Path Traversal (Zip Slip) vulnerability (CWE-23) in `RNTar.java`.

The `extractTgzFile` method used `entry.getName()` directly to construct file paths without validating that the resolved path stays within the intended output directory. A malicious tar archive with entries containing `../` sequences could write files to arbitrary locations on the filesystem.

**Fix**: Before extracting each entry, resolve the canonical path of the output file and verify it starts with the canonical path of the target directory:

```java
String canonicalTarget = new File(outputPath).getCanonicalPath() + File.separator;
// ...
String canonicalDest = outputFile.getCanonicalPath();
if (!canonicalDest.startsWith(canonicalTarget)) {
    throw new SecurityException("Entry is outside of the target dir: " + entryName);
}
```

This validation runs for every entry (both files and directories) before any filesystem write occurs.

Link to Devin session: https://app.devin.ai/sessions/57fda2faffe94d999d22563f9d46048f
Requested by: @shayanshafii
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/metamask-mobile/pull/807?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/metamask-mobile/pull/807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/metamask-mobile/pull/807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->