### PR TITLE
refactor: migrate mcp_service/index.js from JS to TypeScript

### DIFF
--- a/app/core/mcp_service/index.ts
+++ b/app/core/mcp_service/index.ts
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Apache Superset MCP Server
+ *
+ * Entry point for the MCP server when used as a Node.js module.
+ */
+
+import type { ChildProcess } from 'child_process';
+
+interface SupersetMCPServerOptions {
+  transport: string;
+  host: string;
+  port: number;
+  debug: boolean;
+  pythonPath: string | null;
+  supersetRoot: string | null;
+  configPath: string | null;
+}
+
+class SupersetMCPServer {
+  private options: SupersetMCPServerOptions;
+
+  private process: ChildProcess | null;
+
+  constructor(options: Partial<SupersetMCPServerOptions> = {}) {
+    this.options = {
+      transport: options.transport ?? 'http',
+      host: options.host ?? '127.0.0.1',
+      port: options.port ?? 5008,
+      debug: options.debug ?? false,
+      pythonPath: options.pythonPath ?? null,
+      supersetRoot: options.supersetRoot ?? null,
+      configPath: options.configPath ?? null,
+    };
+    this.process = null;
+  }
+
+  start(): void {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+    require('./bin/superset-mcp.js');
+  }
+
+  stop(): void {
+    if (this.process) {
+      this.process.kill();
+      this.process = null;
+    }
+  }
+}
+
+export default SupersetMCPServer;


### PR DESCRIPTION
## Summary

Migrates `superset/mcp_service/index.js` from the `apache-superset` repo into `app/core/mcp_service/index.ts` with a full JS → TS conversion:

- Added `SupersetMCPServerOptions` interface with typed fields (`transport: string`, `port: number`, `debug: boolean`, nullable `pythonPath`/`supersetRoot`/`configPath`)
- Constructor accepts `Partial<SupersetMCPServerOptions>` with `??` defaults
- `process` property typed as `ChildProcess | null` via `import type { ChildProcess } from 'child_process'`
- Class members marked `private`, methods annotated with `void` return types
- Replaced `module.exports` with `export default`

Link to Devin session: https://app.devin.ai/sessions/b98611e1cdfa47c99a850db75733c668
Requested by: @shayanshafii
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/metamask-mobile/pull/1014?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/metamask-mobile/pull/1014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->